### PR TITLE
feat(buttons): updates buttons to npm styles

### DIFF
--- a/src/pivotal-ui/components/buttons/buttons.scss
+++ b/src/pivotal-ui/components/buttons/buttons.scss
@@ -54,7 +54,8 @@ Create block level buttons - those that span the full width of a parent - by add
 
 .btn {
   font-weight: $btn-font-weight;
-  padding: 5px 15px;
+  border-radius: $btn-border-radius-large;
+  padding: 10px 28px;
 
   &.disabled,
   &[disabled],
@@ -71,26 +72,78 @@ name: button_styles
 parent: button
 ---
 
-Button                                                             | Disabled                                                                    | Class                   | Description
------------------------------------------------------------------- | --------------------------------------------------------------------------  | ----------------------- | -----------
-<button class="btn btn-default">Default</button>                   |<button class="btn btn-default" disabled>Default</button>                    | `btn btn-default`       | This is what buttons look like, this is the go to button style.
-<button class="btn btn-default-alt">Default alternate</button>     |<button class="btn btn-default-alt" disabled>Default alternate</button>      | `btn btn-default-alt`   | This is what buttons look like, this is the go to button style (on white backgrounds).
-<button class="btn btn-lowlight">Lowlight</button>                 |<button class="btn btn-lowlight" disabled>Lowlight</button>                  | `btn btn-lowlight`      | Use this button for other actions, like cancel/dismiss
-<button class="btn btn-danger">Delete</button>                     |<button class="btn btn-danger" disabled>Delete</button>                      | `btn btn-danger`        | This button is for delete actions, these actions should also have a confirmation dialog
-<button class="btn btn-highlight">Highlight</button>               |<button class="btn btn-highlight" disabled>Highlight</button>               | `btn btn-highlight`      | Use this button for other important actions, e.g. restarting apps
-<button class="btn btn-highlight-alt">Highlight alternate</button> |<button class="btn btn-highlight-alt" disabled>Highlight alternate</button> | `btn btn-highlight-alt`  | Use this button for other important actions, e.g. marketing call to actions
+
+<table class="styleguide">
+    <tbody>
+    <tr>
+        <th>Button</th>
+        <th>Disabled</th>
+        <th>Class</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td><button class="btn btn-default">Default</button></td>
+        <td><button class="btn btn-default" disabled="">Default</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-default</code></td>
+        <td>This is what buttons look like, this is the go to button style.</td>
+    </tr>
+    <tr class="bg-npm-blue-2">
+        <td><button class="btn btn-default-alt">Default alternate</button></td>
+        <td><button class="btn btn-default-alt" disabled="">Default alternate</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-default-alt</code></td>
+        <td class="type-neutral-11">This is what buttons look like, this is the go to button style (on dark backgrounds).</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-primary">Primary</button></td>
+        <td><button class="btn btn-primary" disabled="">Primary</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-primary</code></td>
+        <td>Use this button for the primary action on a page/section</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-highlight-1">Highlight 1</button></td>
+        <td><button class="btn btn-highlight-1" disabled="">Highlight  1</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-highlight-1</code></td>
+        <td>Use this button for other important actions</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-highlight-2">Highlight 2</button></td>
+        <td><button class="btn btn-highlight-2" disabled="">Highlight  2</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-highlight-2</code></td>
+        <td>Use this button for other important actions</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-highlight-3">Highlight 1</button></td>
+        <td><button class="btn btn-highlight-3" disabled="">Highlight  3</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-highlight-3</code></td>
+        <td>Use this button for other important actions</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-lowlight">Lowlight</button></td>
+        <td><button class="btn btn-lowlight" disabled="">Lowlight</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-lowlight</code></td>
+        <td>Use this button for unimportant or dangerous secondary actions like cancel/dismiss/delete</td>
+    </tr>
+    <tr>
+        <td><button class="btn btn-danger">Delete</button></td>
+        <td><button class="btn btn-danger" disabled="">Delete</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-danger</code></td>
+        <td>This button is for delete actions, within the confirmation dialog, destructive actions should be lowlight within the app</td>
+    </tr>
+    </tbody>
+</table>
+
 */
 
 .btn-default {
-  @include button-skin($btn-default-color, $btn-default-bg, $btn-default-border);
+  @include button-skin($btn-default-color, $btn-default-bg, $btn-default-border, null, $btn-default-border-hover, $background-activated: $btn-default-bg-hover);
 }
 
 .btn-default-alt {
-  @include button-skin($btn-default-alt-color, $btn-default-alt-bg, $btn-default-alt-border);
-  @include button-shadow;
-  &:hover, &:focus {
-    border-color: $btn-default-border-hover;
-  }
+  @include button-skin($btn-default-alt-color, $btn-default-alt-bg, $btn-default-alt-border, null, $btn-default-alt-border-hover);
+}
+
+.btn-primary {
+  @include button-skin($btn-primary-color, $btn-primary-bg, $border: null, $color-disabled: $btn-primary-color-disabled);
 }
 
 .btn-link {
@@ -104,18 +157,19 @@ Button                                                             | Disabled   
 // Danger and error appear as red
 .btn-danger {
   @include button-skin($btn-danger-color, $btn-danger-bg, $border: null, $color-disabled: $btn-danger-color-disabled);
-  @include button-shadow;
 }
 
-.btn-highlight {
-  @include button-skin($btn-highlight-color, $btn-highlight-bg, $border: null, $color-disabled: $btn-highlight-color-disabled);
-  @include button-shadow;
+.btn-highlight-1 {
+  @include button-skin($btn-highlight-1-color, $btn-highlight-1-bg, $border: null, $color-disabled: $btn-highlight-1-color-disabled);
+}
+.btn-highlight-2 {
+  @include button-skin($btn-highlight-2-color, $btn-highlight-2-bg, $border: null, $color-disabled: $btn-highlight-2-color-disabled);
+}
+.btn-highlight-3 {
+  @include button-skin($btn-highlight-3-color, $btn-highlight-3-bg, $border: null, $color-disabled: $btn-highlight-3-color-disabled);
 }
 
-.btn-highlight-alt {
-  @include button-skin($btn-highlight-alt-color, $btn-highlight-alt-bg, $border: null, $color-disabled: $btn-highlight-alt-color-disabled);
-  @include button-shadow;
-}
+
 
 
 /*doc
@@ -129,15 +183,22 @@ There are two sizes for buttons: Large and default. Simply apply the
 size modifier class for the desired size.
 
 ```html_example_table
-<button class="btn btn-default btn-lg">Large</button>
+<button class="btn btn-default btn-sm">Small</button>
 
 <button class="btn btn-default">Default</button>
 ```
 
 */
 
-.btn-lg {
+$btn-sm-padding: 4px 20px;
+$btn-sm-font-size: $font-size-small;
+$btn-sm-line-height: $line-height-small;
+$btn-sm-border-radius: $border-radius-xl;
+
+
+.btn-sm {
+  text-transform: uppercase;
   // line-height: ensure even-numbered height of button next to large input
-  @include button-size($padding-large-vertical, $padding-large-horizontal, $font-size-medium, $line-height-large, $border-radius-small);
+  @include pui-button-size($btn-sm-padding, $btn-sm-font-size, $btn-sm-line-height, $btn-sm-border-radius);
 }
 

--- a/src/pivotal-ui/components/buttons/buttons.scss
+++ b/src/pivotal-ui/components/buttons/buttons.scss
@@ -183,21 +183,20 @@ There are two sizes for buttons: Large and default. Simply apply the
 size modifier class for the desired size.
 
 ```html_example_table
-<button class="btn btn-default btn-sm">Small</button>
+<button class="btn btn-default btn-sm em-alt">Small</button>
 
 <button class="btn btn-default">Default</button>
 ```
 
 */
 
-$btn-sm-padding: 4px 20px;
+$btn-sm-padding: 5px 20px 4px 20px;
 $btn-sm-font-size: $font-size-small;
 $btn-sm-line-height: $line-height-small;
 $btn-sm-border-radius: $border-radius-xl;
 
 
 .btn-sm {
-  text-transform: uppercase;
   // line-height: ensure even-numbered height of button next to large input
   @include pui-button-size($btn-sm-padding, $btn-sm-font-size, $btn-sm-line-height, $btn-sm-border-radius);
 }

--- a/src/pivotal-ui/components/mixins.scss
+++ b/src/pivotal-ui/components/mixins.scss
@@ -14,7 +14,7 @@
 
 /* Button Mixins */
 
-@mixin button-skin($color, $background, $border: null, $color-disabled: null) {
+@mixin button-skin($color, $background, $border: null, $color-disabled: null, $border-hover: null, $background-activated: null) {
   color: $color;
   background-color: $background;
   @if ($border) {
@@ -26,34 +26,62 @@
 
   &:hover,
   &:focus {
-    color: lighten($color, 5%);
-    background-color: lighten($background, 6%);
+    @if($color) {
+      color: lighten($color, 5%);
+    }
+    @if($background-activated) {
+      background-color: $background-activated;
+    } @else {
+      background-color: darken($background, 8%);
+    }
+    @if($border-hover){
+      border-color: $border-hover;
+    }
     outline: none;
   }
   .btn-group & {
     &:active,
     &.active {
-      color: darken($color, 5%);
-      background-color: darken($background, 6%);
+      @if($color) {
+        color: darken($color, 5%);
+      }
+      @if($background) {
+        background-color: darken($background, 8%);
+      }
       box-shadow: none;
       outline: none;
     }
   }
   .open & {
     &.dropdown-toggle {
-      color: darken($color, 5%);
-      background-color: darken($background, 6%);
+      @if($color) {
+        color: darken($color, 5%);
+      }
+      @if($background) {
+        background-color: darken($background, 6%);
+      }
       box-shadow: none;
       &:hover, &:focus {
-        color: darken($color, 5%);
-        background-color: darken($background, 6%);
+        @if($color){
+          color: darken($color, 5%);
+        }
+        @if($background) {
+          background-color: darken($background, 6%);
+        }
+        @if($border-hover){
+          border-color: $border-hover;
+        }
       }
     }
   }
   &:active,
   &.active {
-    color: darken($color, 5%);
-    background-color: darken($background, 6%);
+    @if($color){
+      color: darken($color, 5%);
+    }
+    @if($background) {
+      background-color: darken($background, 6%);
+    }
     box-shadow: none;
     outline: none;
   }
@@ -87,6 +115,13 @@
   &.active{
    box-shadow: none;
   }
+}
+
+@mixin pui-button-size($padding, $font-size, $line-height, $border-radius) {
+  padding: $padding;
+  font-size: $font-size;
+  line-height: $line-height;
+  border-radius: $border-radius;
 }
 
 //Used for translucent borders

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -415,6 +415,7 @@ $line-height-small:              1.5 !default;
 
 $border-radius-base:             4px !default;
 $border-radius-medium:           5px !default;
+$border-radius-xl:               20px;
 $border-radius-large:            6px !default;
 $border-radius-small:            3px !default;
 $border-radius-none:             0;
@@ -460,18 +461,21 @@ $table-scrollable-body-border:   3px solid $neutral-9;
 $btn-font-weight:                600 !default;
 $btn-border-width:               0;
 
-$btn-default-color:              $link-color !default;
-$btn-default-bg:                 $neutral-11 !default;
-$btn-default-border:             $neutral-7 !default; // not currently used, but bootstrap relies on this value
-$btn-default-border-hover:       $neutral-5;
+$btn-default-color:              $npm-navy-2;
+$btn-default-bg:                 $neutral-11;
+$btn-default-bg-hover:           $neutral-11;
+$btn-default-border:             $neutral-7;
+$btn-default-border-hover:       $npm-navy-2;
 
-$btn-default-alt-color:          $link-color;
-$btn-default-alt-bg:             $neutral-11;
-$btn-default-alt-border:         $neutral-7;
+$btn-default-alt-color:          $neutral-11;
+$btn-default-alt-bg:             transparent;
+$btn-default-alt-border:         #979797;
+$btn-default-alt-border-hover:   $neutral-11;
 
-$btn-primary-color:              $accent-3; // not currently used, but bootstrap relies on this value
-$btn-primary-bg:                 white;     // not currently used, but bootstrap relies on this value
-$btn-primary-border:             #49A8D5 !default; // not currently used, but bootstrap relies on this value
+$btn-primary-color:              $neutral-11;
+$btn-primary-bg:                 $npm-navy-2;
+$btn-primary-border:             transparent;
+$btn-primary-color-disabled:     lighten($npm-navy-2, 50%);
 
 $btn-link-color:                 $link-color !default;
 $btn-link-bg:                    transparent !default;
@@ -479,19 +483,17 @@ $btn-link-bg:                    transparent !default;
 $btn-lowlight-color:             $dark-5;
 $btn-lowlight-bg:                $glow-4;
 
-$btn-highlight-color:             $neutral-11;
-$btn-highlight-color-disabled:    $accent-6;
-$btn-highlight-bg:                $accent-3;
+$btn-highlight-1-color:          $neutral-11;
+$btn-highlight-1-color-disabled: lighten($npm-brand, 30%);
+$btn-highlight-1-bg:             $npm-brand;
 
-$btn-highlight-alt-color:         $neutral-11;
-$btn-highlight-alt-color-disabled:$brand-11;
-$btn-highlight-alt-bg:            $brand-6;
+$btn-highlight-2-color:          $neutral-11;
+$btn-highlight-2-color-disabled: lighten($npm-blue-2, 30%);
+$btn-highlight-2-bg:             $npm-blue-2;
 
-
-// alternate is only used on login pages
-$btn-alternate-color:            #eee !default;
-$btn-alternate-bg:               $brand-primary !default;
-$btn-alternate-border:           darken($neutral-11, 5%) !default;
+$btn-highlight-3-color:          $neutral-11;
+$btn-highlight-3-color-disabled: lighten($npm-warm-3, 30%);
+$btn-highlight-3-bg:             $npm-warm-3;
 
 $btn-success-color:              transparent !default;
 $btn-success-bg:                 transparent !default;
@@ -504,10 +506,10 @@ $btn-warning-bg-hover:           transparent;
 $btn-warning-border:             transparent !default;
 
 $btn-danger-color:               $neutral-11;
-$btn-danger-color-disabled:      $error-6;
-$btn-danger-bg:                  $error-4 !default;
-$btn-danger-bg-hover:            $error-5 !default;
-$btn-danger-border:              $brand-danger !default;
+$btn-danger-color-disabled:      lighten($npm-brand, 40%);
+$btn-danger-bg:                  $npm-brand;
+$btn-danger-bg-hover:            darken($npm-brand, 30%);
+$btn-danger-border:              transparent;
 
 $btn-info-color:                 transparent !default;
 $btn-info-bg:                    transparent !default;
@@ -519,9 +521,9 @@ $btn-disabled-color:             $neutral-5;
 
 $btn-link-disabled-color:        $gray-light !default;
 
-$btn-border-radius-base:         $border-radius-base;
-$btn-border-radius-large:        $border-radius-large;
-$btn-border-radius-small:        $border-radius-small;
+$btn-border-radius-base:         $border-radius-xl;
+$btn-border-radius-large:        $border-radius-xl;
+$btn-border-radius-small:        $border-radius-xl;
 
 
 // Forms


### PR DESCRIPTION
BREAKING CHANGE: (class name) .btn-highlight-alt and .btn-highlight deprecated

A few things of note:
- I kept a `.btn-danger` class even though it currently matches our red highlight button. My thought process was that the two seem likely to diverge
- I fudged the disabled styles for v1. I'm hoping Ken tells me all disabled buttons can just be gray. I'll do that in another PR.
- I made the `.btn-sm` class also all-caps. Should it be all caps instead via the addition of the emphasis class instead? @jefflembeck would love to get your opinions.

<img width="190" alt="screen shot 2016-03-09 at 11 10 54 pm" src="https://cloud.githubusercontent.com/assets/39398/13662083/a904dd78-e64c-11e5-9f71-385393937916.png">
<img width="976" alt="screen shot 2016-03-09 at 11 10 42 pm" src="https://cloud.githubusercontent.com/assets/39398/13662082/a902ebb2-e64c-11e5-93c8-cbe163810238.png">
