### PR TITLE
Container docs and container-fullwidth class

### DIFF
--- a/src/pivotal-ui/components/grids/grids.scss
+++ b/src/pivotal-ui/components/grids/grids.scss
@@ -2247,14 +2247,20 @@ name: 11_grid_container
 parent: grid
 ---
 
-Grids must be inside of a `.container` class, which contains the floated elements so that following content does not pile up on to of your layout.
+Grids must be inside of a `.container` class, which contains the floated
+elements so that following content does not pile up on to of your layout.
 
-Plain containers also constrain the width with screen-size-appropriate widths, leaving auto margins to take up the edges. 
+Plain containers also constrain the width with screen-size-appropriate widths,
+leaving auto margins to take up the edges. 
 
-When doing full-width work, you may need the `.container-fullwidth` class in addition.
+When doing full-width work, you may need the `.container-fullwidth` class in
+addition.
+
+Because this relies on a wide viewport to show, it's best demoed on [containers 
+page](/containers.html).
 
 */
 
 .container-fullwidth {
- width: auto !important;
+ max-width: initial !important;
 }

--- a/src/pivotal-ui/components/grids/grids.scss
+++ b/src/pivotal-ui/components/grids/grids.scss
@@ -2239,3 +2239,16 @@ $grids-debug: false;
   }
 
 }
+
+/*doc
+---
+title: Containers
+name: 11_grid_container
+parent: grid
+---
+
+Grids must be inside of a `.container` class, which contains the floated elements so that following content does not pile up on to of your layout.
+
+Plain containers also constrain the width with screen-size-appropriate widths, leaving auto margins to take up the edges. 
+
+*/

--- a/src/pivotal-ui/components/grids/grids.scss
+++ b/src/pivotal-ui/components/grids/grids.scss
@@ -2251,4 +2251,10 @@ Grids must be inside of a `.container` class, which contains the floated element
 
 Plain containers also constrain the width with screen-size-appropriate widths, leaving auto margins to take up the edges. 
 
+When doing full-width work, you may need the `.container-fullwidth` class in addition.
+
 */
+
+.container-fullwidth {
+ width: auto !important;
+}

--- a/src/styleguide/containers.html
+++ b/src/styleguide/containers.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+  <title>Pivotal UI: Pane</title>
+  <link rel="stylesheet" href="pivotal-ui.css">
+  <link rel="stylesheet" href="styleguide/styleguide.css">
+  <link rel="stylesheet" href="prismjs/prism-okaida.css">
+  <script src="pivotal-ui.js"></script>
+  <script src="styleguide/styleguide.js"></script>
+</head>
+<body>
+
+<div class="pane bg-dark-2">
+  <div class="container bg-glow">
+    <h1 class="type-neutral-11">This is a pane with a regular container</h1>
+  </div>
+</div>
+<div class="pane bg-dark-2">
+  <div class="container container-fullwidth bg-glow">
+    <h1 class="type-neutral-11">This is a pane with a fullwidth container</h1>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tasks/monolith.js
+++ b/tasks/monolith.js
@@ -83,7 +83,7 @@ gulp.task('monolith-build-css-from-cache', () => {
 
 gulp.task('monolith-build-css-from-scratch', callback => runSequence('monolith-setup-css-cache', 'monolith-build-css-from-cache', callback));
 
-gulp.task('monolith-html', () => gulp.src('src/styleguide/pane.html')
+gulp.task('monolith-html', () => gulp.src('src/styleguide/*.html')
     .pipe(gulp.dest('build'))
 );
 


### PR DESCRIPTION
The `.container` is from bootstrap but this is not well referenced from our
documentation, so some exposition is useful I think, and gives a place to talk
about `.container-fullwidth`
