### PR TITLE
List styles

### DIFF
--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -156,6 +156,23 @@ parent: list
 </ul>
 ```
 
+Use a different type of bullet in an unordered list (`<ul>`) with `list-unordered-alt`.
+
+```html_example
+<ul class="list-unordered-alt">
+  <li>
+    feep
+  </li>
+  <li>
+    fop
+  </li>
+  <li>
+    meep
+  </li>
+</ul>
+```
+
+
 */
 
 .list-unordered {
@@ -164,6 +181,19 @@ parent: list
   > li {
     margin-left: 17px;
   }
+}
+
+.list-unordered-alt {
+  list-style: none;
+  padding: 0px;
+}
+
+.list-unordered-alt li:before
+{
+  content: '\2022';
+  margin-right: 15px;
+  position: relative;
+  top: -1px;
 }
 
 /*doc
@@ -224,44 +254,6 @@ Places all list items on a single line with `display: inline-block;` and some li
 </ul>
 ```
 */
-
-/*doc
----
-title: Bullet sizes
-name: list_05_bullets
-parent: list
----
-
-Uses tiny bullets in an unordered list (`<ul>`) with `list-style-tiny`.
-
-```html_example
-<ul class="list-style-tiny">
-  <li>
-    feep
-  </li>
-  <li>
-    fop
-  </li>
-  <li>
-    meep
-  </li>
-</ul>
-```
-
-*/
-
-.list-style-tiny {
-  list-style: none;
-  padding: 0px;
-}
-
-.list-style-tiny li:before
-{
-  content: '\2022';
-  margin-right: 15px;
-  position: relative;
-  top: -1px;
-}
 
 /*doc
 ---

--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -158,8 +158,6 @@ parent: list
 
 */
 
-
-
 .list-unordered {
   padding-left: 0;
   list-style-type: disc;
@@ -202,7 +200,30 @@ Nested bullets follow GH indentation.
 </ol>
 ```
 
+To remove the indentation, use the `list-no-indent` class. It can be applied to both `<ul>`s and `<ol>`s.
+
+```html_example
+
+<p>The following list is in line with this paragraph.</p>
+
+<ul class="list-no-indent">
+  <li>
+    feep
+  </li>
+  <li>
+    fop
+  </li>
+  <li>
+    meep
+  </li>
+</ul>
+```
 */
+
+.list-no-indent {
+  list-style-position: inside;
+  padding: 0;
+}
 
 /*doc
 ---

--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -199,31 +199,7 @@ Nested bullets follow GH indentation.
   </li>
 </ol>
 ```
-
-To remove the indentation, use the `list-no-indent` class. It can be applied to both `<ul>`s and `<ol>`s.
-
-```html_example
-
-<p>The following list is in line with this paragraph.</p>
-
-<ul class="list-no-indent">
-  <li>
-    feep
-  </li>
-  <li>
-    fop
-  </li>
-  <li>
-    meep
-  </li>
-</ul>
-```
 */
-
-.list-no-indent {
-  list-style-position: inside;
-  padding: 0;
-}
 
 /*doc
 ---

--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -161,13 +161,13 @@ Use a different type of bullet in an unordered list (`<ul>`) with `list-unordere
 ```html_example
 <ul class="list-unordered-alt">
   <li>
-    feep
+    Bear claw jelly-o jujubes candy muffin chocolate bar sweet roll powder. Topping cake chocolate cake candy toffee. Toffee danish candy pie halvah danish. Bear claw toffee candy liquorice.
   </li>
   <li>
-    fop
+    Tootsie roll gummi bears cake. Fruitcake caramels jelly-o cake. Gummi bears jelly-o macaroon gingerbread. Marshmallow brownie candy ice cream candy canes gingerbread icing sweet roll.
   </li>
   <li>
-    meep
+    Chupa chups bonbon cupcake. Tootsie roll gummies bonbon ice cream muffin dessert icing. Brownie dragée sesame snaps biscuit cake macaroon donut gummies tootsie roll. Cotton candy apple pie cake muffin danish toffee.
   </li>
 </ul>
 ```
@@ -186,6 +186,11 @@ Use a different type of bullet in an unordered list (`<ul>`) with `list-unordere
 .list-unordered-alt {
   list-style: none;
   padding: 0px;
+}
+
+.list-unordered-alt li {
+  padding-left: 23px;
+  text-indent: -23px;
 }
 
 .list-unordered-alt li:before

--- a/src/pivotal-ui/components/lists/lists.scss
+++ b/src/pivotal-ui/components/lists/lists.scss
@@ -232,7 +232,7 @@ name: list_04_unstyled
 parent: list
 ---
 
-Places all list items on a single line with `display: inline-block;` and some light padding. The `.list-unstyled` class can be applied to either a `<ul>` or and `<ol>`.
+Places all list items on a single line with `display: inline-block;` and some light padding. The `.list-unstyled` class can be applied to either a `<ul>` or `<ol>`.
 
 ```html_example
 <ul class="list-unstyled">
@@ -247,8 +247,45 @@ Places all list items on a single line with `display: inline-block;` and some li
   </li>
 </ul>
 ```
+*/
+
+/*doc
+---
+title: Bullet sizes
+name: list_05_bullets
+parent: list
+---
+
+Uses tiny bullets in an unordered list (`<ul>`) with `list-style-tiny`.
+
+```html_example
+<ul class="list-style-tiny">
+  <li>
+    feep
+  </li>
+  <li>
+    fop
+  </li>
+  <li>
+    meep
+  </li>
+</ul>
+```
 
 */
+
+.list-style-tiny {
+  list-style: none;
+  padding: 0px;
+}
+
+.list-style-tiny li:before
+{
+  content: '\2022';
+  margin-right: 15px;
+  position: relative;
+  top: -1px;
+}
 
 /*doc
 ---

--- a/src/pivotal-ui/components/lists/package.json
+++ b/src/pivotal-ui/components/lists/package.json
@@ -5,5 +5,5 @@
     "pui-css-iconography": "2.0.0",
     "pui-css-typography": "2.0.0"
   },
-  "version": "2.1.0"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
Adds two list components:

1) in-line lists
<img width="346" alt="screen shot 2016-03-11 at 5 43 22 pm" src="https://cloud.githubusercontent.com/assets/954269/13759621/553d9a24-e9ec-11e5-8309-a6daddc336be.png">

2) tiny bullet sizes
![screen shot 2016-03-14 at 1 55 41 pm](https://cloud.githubusercontent.com/assets/954269/13759657/7c7eb974-e9ec-11e5-8b72-98dad7f5ccd7.png)

These are in preparation for styles needed for designs like this: 
![screen shot 2016-03-14 at 1 56 20 pm](https://cloud.githubusercontent.com/assets/954269/13759678/90482e72-e9ec-11e5-8f08-cc0636780f25.png)
