### PR TITLE
GIGANTIC font size

### DIFF
--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -367,6 +367,8 @@ $line-height-computed:    floor($font-size-base * $line-height-base) !default; /
 
 $font-size-title:         48px;
 
+$font-size-gigantic:      71px;
+
 // Whitespace
 // -------------------------
 $whitespace-s:        5px;

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -75,6 +75,8 @@ Set font sizes using headings and modifier classes.
 <p class="type-sm">small text 13px</p>
 
 <p class="type-xs">extra small text 12px</p>
+
+<p class="type-gigantic">gigantic 71px</p>
 ```
 
 <div class="alert alert-info mbxl">
@@ -180,6 +182,10 @@ small,
 
 .title {
   font-size: $font-size-title;
+}
+
+.type-gigantic {
+  font-size: $font-size-gigantic;
 }
 
 /*doc


### PR DESCRIPTION
(We need it for the pricing pane :-))

here's what it looks like:
<img width="960" alt="screen shot 2016-03-17 at 5 01 20 pm" src="https://cloud.githubusercontent.com/assets/954269/13864807/f0add902-ec61-11e5-81b8-814eec32b0f1.png">
