### PR TITLE
fix(typography): Remove !important from header weight

### DIFF
--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "font-awesome": "^4.4.0"
   },
-  "version": "3.0.1"
+  "version": "4.0.0"
 }

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -147,32 +147,32 @@ h4, .h4, h5, .h5, h6, .h6 {
 
 .h1 {
   font-size: $font-size-h1 !important;
-  font-weight: $font-weight-h1 !important;
+  font-weight: $font-weight-h1;
 }
 
 .h2 {
   font-size: $font-size-h2 !important;
-  font-weight: $font-weight-h2 !important;
+  font-weight: $font-weight-h2;
 }
 
 .h3 {
   font-size: $font-size-h3 !important;
-  font-weight: $font-weight-h3 !important;
+  font-weight: $font-weight-h3;
 }
 
 .h4 {
   font-size: $font-size-h4 !important;
-  font-weight: $font-weight-h4 !important;
+  font-weight: $font-weight-h4;
 }
 
 .h5 {
   font-size: $font-size-h5 !important;
-  font-weight: $font-weight-h5 !important;
+  font-weight: $font-weight-h5;
 }
 
 .h6 {
   font-size: $font-size-h6 !important;
-  font-weight: $font-weight-h6 !important;
+  font-weight: $font-weight-h6;
 }
 
 small,


### PR DESCRIPTION
BREAKING CHANGE: Header font-weight should be a default, but should be
able to be easily overwritten by an emphasis class, since the weight is
not the primary purpose for it as a class.
