### PR TITLE
feat(viewport-panes): don't show at certain sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@npmcorp/pui-css-typography": "^3.0.1",
     "@npmcorp/pui-css-utils": "^2.2.0",
     "@npmcorp/pui-css-vertical-alignment": "^2.0.0",
-    "@npmcorp/pui-css-viewport-panes": "^1.1.0",
+    "@npmcorp/pui-css-viewport-panes": "^2.0.0",
     "@npmcorp/pui-css-whitespace": "^2.0.0",
     "@npmcorp/pui-react-alerts": "^2.0.0",
     "@npmcorp/pui-react-back-to-top": "^2.0.0",

--- a/src/pivotal-ui/components/viewport-panes/package.json
+++ b/src/pivotal-ui/components/viewport-panes/package.json
@@ -5,5 +5,5 @@
     "@npmcorp/pui-css-panes": "^2.0.0",
     "@npmcorp/pui-css-header": "^2.0.4"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/src/pivotal-ui/components/viewport-panes/package.json
+++ b/src/pivotal-ui/components/viewport-panes/package.json
@@ -5,5 +5,5 @@
     "@npmcorp/pui-css-panes": "^2.0.0",
     "@npmcorp/pui-css-header": "^2.0.4"
   },
-  "version": "1.1.1"
+  "version": "2.0.1"
 }

--- a/src/pivotal-ui/components/viewport-panes/viewport-panes.scss
+++ b/src/pivotal-ui/components/viewport-panes/viewport-panes.scss
@@ -92,43 +92,43 @@ These situations all assume a scenario where the viewport height at least `600px
   <tbody>
     <tr>
       <th class="no-wrap"><code>.not-full-viewport-xs</code></th>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
+      <td class="is-hidden">Not full screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
     </tr>
     <tr>
       <th class="no-wrap"><code>.not-full-viewport-sm</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-hidden">Not full screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
     </tr>
     <tr>
       <th class="no-wrap"><code>.not-full-viewport-md</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-hidden">Not full screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
     </tr>
     <tr>
       <th class="no-wrap"><code>.not-full-viewport-lg</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
-      <td class="is-visible">Visible</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-hidden">Not full screen</td>
+      <td class="is-visible">Full Screen</td>
     </tr>
     <tr>
       <th class="no-wrap"><code>.not-full-viewport-xl</code></th>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-visible">Visible</td>
-      <td class="is-hidden">Hidden</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-visible">Full Screen</td>
+      <td class="is-hidden">Not full screen</td>
     </tr>
   </tbody>
 </table>

--- a/src/pivotal-ui/components/viewport-panes/viewport-panes.scss
+++ b/src/pivotal-ui/components/viewport-panes/viewport-panes.scss
@@ -59,6 +59,82 @@ to come through
 </div>
 ```
 
+In the case where you'd like the viewport to not show up at certain viewport sizes, you can use
+`not-full-viewport-*` syntax.
+
+These situations all assume a scenario where the viewport height at least `600px`.
+<table class="styleguide">
+  <thead>
+    <tr>
+      <th></th>
+      <th>
+        Extra small devices
+        <small>Phones (&lt;768px)</small>
+      </th>
+      <th>
+        Small devices
+        <small>Tablets (&geq;768px)</small>
+      </th>
+      <th>
+        Medium devices
+        <small>Desktops (&geq;992px)</small>
+      </th>
+      <th>
+        Large devices
+        <small>Desktops (&geq;1200px)</small>
+      </th>
+      <th>
+        Extra large devices
+        <small>Desktops (&geq;1600px)</small>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th class="no-wrap"><code>.not-full-viewport-xs</code></th>
+      <td class="is-hidden">Hidden</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+    </tr>
+    <tr>
+      <th class="no-wrap"><code>.not-full-viewport-sm</code></th>
+      <td class="is-visible">Visible</td>
+      <td class="is-hidden">Hidden</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+    </tr>
+    <tr>
+      <th class="no-wrap"><code>.not-full-viewport-md</code></th>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-hidden">Hidden</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+    </tr>
+    <tr>
+      <th class="no-wrap"><code>.not-full-viewport-lg</code></th>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-hidden">Hidden</td>
+      <td class="is-visible">Visible</td>
+    </tr>
+    <tr>
+      <th class="no-wrap"><code>.not-full-viewport-xl</code></th>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-visible">Visible</td>
+      <td class="is-hidden">Hidden</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
 */
 
 .viewport-pane,
@@ -76,5 +152,35 @@ to come through
   }
   .viewport-pane-long {
     min-height: calc(100vh - 2em - #{$header-height-max-lg});
+  }
+}
+
+@media (min-height: $screen-height-sm) and (max-width: $screen-xs-max) {
+  .viewport-pane.not-full-viewport-xs {
+    min-height: 0 !important;
+  }
+}
+
+@media (min-height: $screen-height-sm) and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
+  .viewport-pane.not-full-viewport-sm {
+    min-height: 0 !important;
+  }
+}
+
+@media (min-height: $screen-height-sm) and (min-width: $screen-md-min) and (max-width: $screen-md-max) {
+  .viewport-pane.not-full-viewport-md {
+    min-height: 0 !important;
+  }
+}
+
+@media (min-height: $screen-height-sm) and (min-width: $screen-lg-min) and (max-width: $screen-lg-max) {
+  .viewport-pane.not-full-viewport-lg {
+    min-height: 0 !important;
+  }
+}
+
+@media (min-height: $screen-height-sm) and (min-width: $screen-xl-min) {
+  .viewport-pane.not-full-viewport-xl {
+    min-height: 0 !important;
   }
 }


### PR DESCRIPTION
Viewport panes are very useful, but at some breakpoints, they just don't
work with what you're trying to accomplish. Adding this rule allows you
to turn off that functionality at certain BPs
