### PR TITLE
chore(header): bump version for curiosity

### DIFF
--- a/src/pivotal-ui/components/header/package.json
+++ b/src/pivotal-ui/components/header/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-drop-down-menu": "^1.3.0",
     "@npmcorp/pui-css-typography": "^4.0.0"
   },
-  "version": "2.1.1"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
Some minor changes have rolled through in header lately and I was diagnosing some build issues.

Integers are free, so here is a new version.
