### PR TITLE
feat(typography): adds a `.em-medium` class

### DIFF
--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -332,6 +332,7 @@ $font-size-extra-small:   12px;
 
 $font-weight-em-low:      300;
 $font-weight-em-default:  400;
+$font-weight-em-medium:   600;
 $font-weight-em-high:     700;
 $font-weight-em-max:      800;
 

--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "font-awesome": "^4.4.0"
   },
-  "version": "4.0.0"
+  "version": "4.1.0"
 }

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -212,6 +212,8 @@ Here's a table of all the emphasis modifier classes.
 
 <h1 class="em-default">Default emphasis</h1>
 
+<h1 class="em-medium">Medium emphasis</h1>
+
 <h1 class="em-high">High emphasis</h1>
 
 <h1 class="em-max">Maximum emphasis</h1>
@@ -223,6 +225,7 @@ Here's a table of all the emphasis modifier classes.
 
 .em-low { font-weight: $font-weight-em-low !important; }
 .em-default { font-weight: $font-weight-em-default !important; }
+.em-medium { font-weight: $font-weight-em-medium !important; }
 .em-high { font-weight: $font-weight-em-high !important; }
 .em-max { font-weight: $font-weight-em-max !important; }
 .em-alt { text-transform: uppercase !important; }


### PR DESCRIPTION
`.em-medium` will now make its elements semibold, or 600 weight

[finishes #116903143]

![screen shot 2016-04-07 at 4 23 34 pm](https://cloud.githubusercontent.com/assets/954269/14369828/1ad0d532-fcdd-11e5-8896-7a55c9a08e78.png)
