### PR TITLE
fix(forms): Export stepper component

### DIFF
--- a/src/pivotal-ui/components/forms/index.js
+++ b/src/pivotal-ui/components/forms/index.js
@@ -1,1 +1,1 @@
-require('./stepper');
+exports.stepper = require('./stepper');

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -4,5 +4,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "2.1.1"
+  "version": "2.1.2"
 }


### PR DESCRIPTION
Make sure that when the forms component is required, the stepper
component is able to be accessed (for testing, etc)
