### PR TITLE
fix(forms): remove max default on form stepper

### DIFF
--- a/src/pivotal-ui/components/autocomplete/package.json
+++ b/src/pivotal-ui/components/autocomplete/package.json
@@ -3,7 +3,7 @@
   "homepage": "http://styleguide.pivotal.io/react.html#autocomplete_react",
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
-    "@npmcorp/pui-css-forms": "^2.0.1"
+    "@npmcorp/pui-css-forms": "^3.0.0"
   },
-  "version": "2.0.2"
+  "version": "2.0.3"
 }

--- a/src/pivotal-ui/components/forms/forms.scss
+++ b/src/pivotal-ui/components/forms/forms.scss
@@ -1325,7 +1325,7 @@ text field by interacting with one of two buttons.
     <label class="control-label" for="subscribers">Subscriber count</label>
     <div class="form-stepper">
       <button type="button" class="btn btn-default btn-decrement" title="decrement value"><span class="a11y-only">decrement value</span>&minus;</button>
-      <input class="form-control" min="1" max="99999" step="1" name="subscribers" required="" type="number" value=10>
+      <input class="form-control" min="1" step="1" name="subscribers" required="" type="number" value=1>
       <button type="button" class="btn btn-default btn-increment" title="increment value"><span class="a11y-only">increment value</span>+</button>
     </div>
   </div>

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -4,5 +4,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "3.0.1"
+  "version": "3.0.2"
 }

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -4,5 +4,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "2.1.2"
+  "version": "3.0.0"
 }

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -4,5 +4,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "3.0.0"
+  "version": "3.0.1"
 }

--- a/src/pivotal-ui/components/forms/stepper.js
+++ b/src/pivotal-ui/components/forms/stepper.js
@@ -5,7 +5,8 @@ var FormStepper = function(el, input, decrementButton, incrementButton){
   this.incrementButton = incrementButton || this.stepper.find(".btn-increment");
 
   this.min = parseInt(this.input.attr("min")) || 0;
-  this.max = parseInt(this.input.attr("max"));
+  var max = parseInt(this.input.attr("max"));
+  this.max = isNaN(max) ? null : max;
   this.value = parseInt(this.input.val()) || parseInt(this.min);
 };
 
@@ -24,7 +25,7 @@ FormStepper.prototype.set = function(number){
 
   if( number <= this.min ){
     number = this.min;
-  } else if (this.max && number >= this.max ){
+  } else if (this.max !== null && number >= this.max ){
     number = this.max;
   }
 

--- a/src/pivotal-ui/components/forms/stepper.js
+++ b/src/pivotal-ui/components/forms/stepper.js
@@ -5,7 +5,7 @@ var FormStepper = function(el, input, decrementButton, incrementButton){
   this.incrementButton = incrementButton || this.stepper.find(".btn-increment");
 
   this.min = parseInt(this.input.attr("min")) || 0;
-  this.max = parseInt(this.input.attr("max")) || 99999;
+  this.max = parseInt(this.input.attr("max"));
   this.value = parseInt(this.input.val()) || parseInt(this.min);
 };
 
@@ -24,7 +24,7 @@ FormStepper.prototype.set = function(number){
 
   if( number <= this.min ){
     number = this.min;
-  } else if (number >= this.max ){
+  } else if (this.max && number >= this.max ){
     number = this.max;
   }
 


### PR DESCRIPTION
There should be no max default for the stepper component

BREAKING CHANGE: This could break tests down the line and any
assumptions made when the max value was not set. Originally, the max
defaulted to 99999. If a user had left the `max` attribute out of the
input element, with this change, there is no longer that default max to
fall back on
