### PR TITLE
fix(forms): Better match current forms

### DIFF
--- a/src/pivotal-ui/components/forms/forms.scss
+++ b/src/pivotal-ui/components/forms/forms.scss
@@ -1324,9 +1324,9 @@ text field by interacting with one of two buttons.
   <div class="form-group">
     <label class="control-label" for="subscribers">Subscriber count</label>
     <div class="form-stepper">
-      <button type="button" class="btn btn-default btn-decrement" title="decrement value"><span class="a11y-only">decrement value</span>&minus;</button>
+      <button type="button" class="btn btn-default btn-decrement form-control" title="decrement value"><span class="a11y-only">decrement value</span>&minus;</button>
       <input class="form-control" min="1" step="1" name="subscribers" required="" type="number" value=1>
-      <button type="button" class="btn btn-default btn-increment" title="increment value"><span class="a11y-only">increment value</span>+</button>
+      <button type="button" class="btn btn-default btn-increment form-control" title="increment value"><span class="a11y-only">increment value</span>+</button>
     </div>
   </div>
 </form>
@@ -1351,15 +1351,10 @@ text field by interacting with one of two buttons.
     text-align: center;
   }
 
-  input[type=number],
   button {
-    display: inline-block;
-    vertical-align: middle;
-  }
-
-  button {
-    border-radius: 4px;
+    line-height: 1;
     padding: 10px 15px;
+    border-radius: 4px;
     text-align: center;
   }
 }

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -4,5 +4,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "3.0.2"
+  "version": "3.0.3"
 }


### PR DESCRIPTION
The buttons for the stepper component were originally set to match the
upcoming form element design. This brings them back into the present.

I double-checked with Jerry on this to make sure these are where he would go with it as well.

Here's how they look:

![pivotal ui css forms 2016-04-18 15-16-00](https://cloud.githubusercontent.com/assets/109699/14621540/7e5b8360-0578-11e6-973f-9c71c8affab2.png)
