### PR TITLE
fix(iconography): icon-avatar -> avatar-icon

### DIFF
--- a/src/pivotal-ui/components/iconography/iconography.scss
+++ b/src/pivotal-ui/components/iconography/iconography.scss
@@ -142,7 +142,7 @@ There are a bunch of little cartoon people that we can use as avatar icons throu
 
 <div class="media">
   <div class="media-left media-middle">
-    <i class="icon icon-avatar" style="background-image: url(styleguide/avatar.svg)"></i>
+    <i class="avatar-icon" style="background-image: url(styleguide/avatar.svg)"></i>
   </div>
   <div class="media-body">
     <h4 class="media-heading">Media heading</h4>
@@ -152,7 +152,7 @@ There are a bunch of little cartoon people that we can use as avatar icons throu
 ```
 */
 
-.icon-avatar {
+.avatar-icon {
   height: 100px;
   width: 100px;
   display: inline-block;

--- a/src/pivotal-ui/components/iconography/package.json
+++ b/src/pivotal-ui/components/iconography/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "@npmcorp/pui-css-typography": "^4.0.0"
   },
-  "version": "2.1.3"
+  "version": "3.0.0"
 }


### PR DESCRIPTION
The `icon-avatar` class was being paired with `icon` in documentation,
and this was causing a conflict when both were being used together. So
this use-case has been removed from the docs.

Also, `icon-avatar` is being changed to `avatar-icon` so as to limit
confusion if `icon` and `icon-avatar` should be used together.

BREAKING CHANGE: Any case where icon-avatar is being used needs to be
changed to avatar-icon and if there is a sibling icon class, it needs to
be removed
