### PR TITLE
chore(iconography): bump version

### DIFF
--- a/src/pivotal-ui/components/iconography/package.json
+++ b/src/pivotal-ui/components/iconography/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "@npmcorp/pui-css-typography": "^4.0.0"
   },
-  "version": "3.0.0"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
iconography was deprecated for 3.0.0, moving to 4.0
