### PR TITLE
Cover avatar icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@npmcorp/pui-css-grids": "^2.1.1",
     "@npmcorp/pui-css-header": "^2.2.0",
     "@npmcorp/pui-css-hoverable": "^2.0.0",
-    "@npmcorp/pui-css-iconography": "^4.0.0",
+    "@npmcorp/pui-css-iconography": "^4.0.1",
     "@npmcorp/pui-css-images": "^2.0.1",
     "@npmcorp/pui-css-labels": "^2.0.1",
     "@npmcorp/pui-css-links": "^2.3.0",

--- a/src/pivotal-ui/components/iconography/iconography.scss
+++ b/src/pivotal-ui/components/iconography/iconography.scss
@@ -156,4 +156,6 @@ There are a bunch of little cartoon people that we can use as avatar icons throu
   height: 100px;
   width: 100px;
   display: inline-block;
+  background-size: contain;
+  background-repeat: no-repeat;
 }

--- a/src/pivotal-ui/components/iconography/package.json
+++ b/src/pivotal-ui/components/iconography/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "@npmcorp/pui-css-typography": "^4.0.0"
   },
-  "version": "4.0.0"
+  "version": "4.0.1"
 }


### PR DESCRIPTION
Avatar icons should take the entire space of what their width and height
are. They also should not repeat.
