### PR TITLE
feat: add lined-heading class to typography

### DIFF
--- a/src/pivotal-ui/components/dividers/dividers.scss
+++ b/src/pivotal-ui/components/dividers/dividers.scss
@@ -1,3 +1,5 @@
+@import "../pui-variables";
+
 /*doc
 ---
 title: Dividers
@@ -30,21 +32,21 @@ Dividers draw horizontal lines between different content groupings.
 
 
 .divider-alternate-1 {
-  border: 1px solid rgba(0,0,0,0.1);
+  border: 1px solid $divider-alternate-1-color;
   border-width: 1px 0 0 0;
 }
 
 .divider-alternate-2 {
-  border: 3px solid rgba(0,0,0,0.1);
+  border: 3px solid $divider-alternate-2-color;
   border-width: 3px 0 0 0;
 }
 
 .divider-1 {
-  border: 1px solid rgba(255,255,255,0.1);
+  border: 1px solid $divider-1-color;
   border-width: 1px 0 0 0;
 }
 
 .divider-2 {
-  border: 3px solid rgba(255,255,255,0.1);
+  border: 3px solid $divider-2-color;
   border-width: 3px 0 0 0;
 }

--- a/src/pivotal-ui/components/dividers/dividers.scss
+++ b/src/pivotal-ui/components/dividers/dividers.scss
@@ -21,32 +21,44 @@ Dividers draw horizontal lines between different content groupings.
 ```html_example
 <hr class="divider-alternate-1"/>
 <hr class="divider-alternate-2"/>
+<hr class="divider-alternate-3"/>
 ```
 
 ```html_inverse_example
 <hr class="divider-1"/>
 <hr class="divider-2"/>
+<hr class="divider-3"/>
 ```
 
 */
 
 
 .divider-alternate-1 {
-  border: 1px solid $divider-alternate-1-color;
+  border: 1px solid $divider-alternate-color;
   border-width: 1px 0 0 0;
 }
 
 .divider-alternate-2 {
-  border: 3px solid $divider-alternate-2-color;
+  border: 2px solid $divider-alternate-color;
+  border-width: 2px 0 0 0;
+}
+
+.divider-alternate-3 {
+  border: 3px solid $divider-alternate-color;
   border-width: 3px 0 0 0;
 }
 
 .divider-1 {
-  border: 1px solid $divider-1-color;
+  border: 1px solid $divider-color;
   border-width: 1px 0 0 0;
 }
 
 .divider-2 {
-  border: 3px solid $divider-2-color;
+  border: 2px solid $divider-color;
+  border-width: 2px 0 0 0;
+}
+
+.divider-3 {
+  border: 3px solid $divider-color;
   border-width: 3px 0 0 0;
 }

--- a/src/pivotal-ui/components/dividers/package.json
+++ b/src/pivotal-ui/components/dividers/package.json
@@ -1,5 +1,5 @@
 {
   "homepage": "http://styleguide.pivotal.io/elements.html#divider",
   "dependencies": {},
-  "version": "3.0.0-alpha.0"
+  "version": "3.0.0"
 }

--- a/src/pivotal-ui/components/dividers/package.json
+++ b/src/pivotal-ui/components/dividers/package.json
@@ -1,5 +1,5 @@
 {
   "homepage": "http://styleguide.pivotal.io/elements.html#divider",
   "dependencies": {},
-  "version": "2.0.0"
+  "version": "3.0.0-alpha.0"
 }

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -1267,10 +1267,8 @@ $ribbon-color: $neutral-11;
 
 // Hr border color
 $hr-border:                   $gray-lighter !default;
-$divider-1-color:             rgba(255,255,255,0.1);
-$divider-2-color:             $divider-1-color;
-$divider-alternate-1-color:   rgba(0,0,0,0.1);
-$divider-alternate-2-color:   $divider-alternate-1-color;
+$divider-color:               rgba(255,255,255,0.1);
+$divider-alternate-color:     rgba(0,0,0,0.1);
 
 // Horizontal forms & lists
 $component-offset-horizontal: 180px !default;

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -1267,6 +1267,10 @@ $ribbon-color: $neutral-11;
 
 // Hr border color
 $hr-border:                   $gray-lighter !default;
+$divider-1-color:             rgba(255,255,255,0.1);
+$divider-2-color:             $divider-1-color;
+$divider-alternate-1-color:   rgba(0,0,0,0.1);
+$divider-alternate-2-color:   $divider-alternate-1-color;
 
 // Horizontal forms & lists
 $component-offset-horizontal: 180px !default;

--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "font-awesome": "^4.4.0"
   },
-  "version": "4.1.0"
+  "version": "4.2.0-alpha.0"
 }

--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "font-awesome": "^4.4.0"
   },
-  "version": "4.2.0-alpha.1"
+  "version": "4.2.0"
 }

--- a/src/pivotal-ui/components/typography/package.json
+++ b/src/pivotal-ui/components/typography/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "font-awesome": "^4.4.0"
   },
-  "version": "4.2.0-alpha.0"
+  "version": "4.2.0-alpha.1"
 }

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -893,7 +893,7 @@ so the line is blocked out by the text. Also use `txt-c` to make sure text is ce
     border-bottom: 2px solid $divider-alternate-color;
     position: absolute;
     width: 100%;
-    bottom: calc(0.5em + 2px);
+    bottom: 1ex;
     z-index: 0;
   }
 }

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -865,6 +865,48 @@ Headings are spaced so their line height and padding are consistent on one or ma
 
 /*doc
 ---
+title: Lined Heading
+name: type_lined
+parent: type
+---
+
+Lined headings jazz up a normal heading with a background divider. It's cool, trust me.
+
+Use in conjunction with a background class so the line is blocked out by the text.
+
+Also use the `txt-c` class to make sure text is center-aligned.
+
+**Note**: lined headings are not meant to be used for multiline text.
+
+```html_example_table
+<h3 class="lined-heading bg-neutral-11 txt-c"><span>One line heading</span></h3>
+```
+
+*/
+
+.lined-heading {
+  position: relative;
+  &:after {
+    display: block;
+    content: " ";
+    border-bottom: 2px solid $divider-alternate-1-color;
+    position: absolute;
+    height: 1px;
+    width: 100%;
+    bottom: calc(0.5em + 2px);
+    z-index: 0;
+  }
+}
+
+.lined-heading > span {
+    position: relative;
+    z-index: 1;
+    padding: 0 0.9375em;
+    background: inherit;
+}
+
+/*doc
+---
 title: Helpers
 name: type_helpers
 parent: type

--- a/src/pivotal-ui/components/typography/typography.scss
+++ b/src/pivotal-ui/components/typography/typography.scss
@@ -865,18 +865,19 @@ Headings are spaced so their line height and padding are consistent on one or ma
 
 /*doc
 ---
-title: Lined Heading
+title: Lined Headings
 name: type_lined
 parent: type
 ---
 
 Lined headings jazz up a normal heading with a background divider. It's cool, trust me.
 
-Use in conjunction with a background class so the line is blocked out by the text.
+Requires heading text to be wrapped in a nested `<span>`.
 
-Also use the `txt-c` class to make sure text is center-aligned.
+Use the `lined-heading` class in conjunction with a background class, e.g. `bg-neutral-11`,
+so the line is blocked out by the text. Also use `txt-c` to make sure text is center-aligned.
 
-**Note**: lined headings are not meant to be used for multiline text.
+**Note**: Lined headings are not meant to be used for multiline text.
 
 ```html_example_table
 <h3 class="lined-heading bg-neutral-11 txt-c"><span>One line heading</span></h3>
@@ -889,9 +890,8 @@ Also use the `txt-c` class to make sure text is center-aligned.
   &:after {
     display: block;
     content: " ";
-    border-bottom: 2px solid $divider-alternate-1-color;
+    border-bottom: 2px solid $divider-alternate-color;
     position: absolute;
-    height: 1px;
     width: 100%;
     bottom: calc(0.5em + 2px);
     z-index: 0;


### PR DESCRIPTION
[finishes: #119242391]

Looks like this:

<img width="910" alt="screen shot 2016-05-11 at 4 42 03 pm" src="https://cloud.githubusercontent.com/assets/1929625/15195773/5692c0f6-1797-11e6-9455-69a7843aee79.png">

Jeff did all the real work.
