### PR TITLE
feat(panels): Scroll overflowed panels rather than hiding

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@npmcorp/pui-css-media": "^2.0.1",
     "@npmcorp/pui-css-meta": "^1.0.0",
     "@npmcorp/pui-css-modals": "^2.0.1",
-    "@npmcorp/pui-css-panels": "^2.1.0",
+    "@npmcorp/pui-css-panels": "^3.1.0",
     "@npmcorp/pui-css-panes": "^2.0.1",
     "@npmcorp/pui-css-progress-bars": "^2.0.1",
     "@npmcorp/pui-css-ribbons": "^2.0.0",

--- a/src/pivotal-ui/components/panels/package.json
+++ b/src/pivotal-ui/components/panels/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/src/pivotal-ui/components/panels/panels.scss
+++ b/src/pivotal-ui/components/panels/panels.scss
@@ -176,7 +176,7 @@ Add `.panel-table-wrapper` if you're containing a table.
 }
 
 .panel-table-wrapper {
-  overflow: hidden;
+  overflow: scroll;
 }
 
 /*doc


### PR DESCRIPTION
This lets big tables remain at least marginally useful when clipped by a
panel, rather than being truncated.
