### PR TITLE
fix(header): npm expansions that push the other menu items into place instead of coincidentally working

### DIFF
--- a/src/pivotal-ui/components/header/header.scss
+++ b/src/pivotal-ui/components/header/header.scss
@@ -346,8 +346,8 @@ header a:hover {
   header > .header-nav-menu-container .nav-menu-container {
     flex: 1 auto;
   }
-  header > .header-nav-menu-container .nav-menu-container {
-    max-width: 650px;
+  header > .header-nav-menu-container .npm-expansions {
+    flex-grow: 10;
   }
   header.hero-transparent + .pane {
     margin-top: -6em;


### PR DESCRIPTION
The max-width of 650px was chosen to fit our current font and current words -- any additions would be disruptive to the header, causing wrapping. this gives a bit more breathing room by making all the flexes play together.
