### PR TITLE
fix(tables): Table designs clearly shown

### DIFF
--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -25,6 +25,8 @@ Class                 | Description
 `.table-striped`      | Applies zebra striping to a table.
 `.table-divided`      | Adds vertical dividers to tables.
 
+You can use grid column classes on `th` and `td` elements. See key-value table for example.
+
 */
 
 @mixin table-vert-divided() {
@@ -75,7 +77,7 @@ name: 1_table_data
 parent: table
 ---
 
-This is a table used to display many rows of data (it is pretty much the default table). You can use grid column classes on th and td elements. See key-value table for example.
+This is a table used to display many rows of data (it is pretty much the default table).
 
 ```html_example
 <div class="panel panel-basic-alt panel-table-wrapper">

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -71,7 +71,7 @@ table, .table {
 /*doc
 ---
 title: Data
-name: table_data
+name: 1_table_data
 parent: table
 ---
 
@@ -88,7 +88,7 @@ This is a table used to display many rows of data (it is pretty much the default
           <th>Cuteness</th>
         </tr>
       </thead>
-      <tbody>
+      <tbody class="bg-neutral-11">
         <tr>
           <td>Baby Wombat</td>
           <td>100</td>
@@ -110,7 +110,16 @@ This is a table used to display many rows of data (it is pretty much the default
 </div>
 ```
 
-With divisions between cells:
+*/
+
+/*doc
+---
+title: Alternate
+name: 2_table_alt
+parent: table
+---
+
+Another table style we intend to use.
 
 ```html_example
 <div class="panel panel-basic-alt panel-table-wrapper">


### PR DESCRIPTION
Give table styles the names "Data" and "Alternate"; "Data" is white-bodied vertical-dividerless; "Alternate" is gray, with vertical dividers.

Also describes how grid styles apply to tables globally, rather than as part of Data tables.

No code change at all, just styleguide section naming and explanation.
