### PR TITLE
deploy ANY branch! WOO!

### DIFF
--- a/configuration.tmpl
+++ b/configuration.tmpl
@@ -1,7 +1,7 @@
-app = "styleguide"
+app = "pivotal-ui"
 description = "bootstrap on steroids"
 start = "node server.js"
 processes = 4
 
 [environment]
-  PORT = ""808%i""
+  PORT = "808%i"

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "pui-update": "scripts/pui-update.js",
     "dev": "gulp dev",
     "build-monolith": "gulp monolith-build-css-from-scratch",
-    "post-install": "gulp monolith"
+    "postinstall": "bundle install && gulp monolith"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
with this PR, we can deploy ANY branch!

a yak has been shaved and now branches can be deployed to `deploy-production` with 

``` shell
git push origin +$(git symbolic-ref --short -q HEAD):deploy-production
```

the monolith build now happens within the styleguide server itself, which will enable a smoother process all around :-)
