### PR TITLE
fix(dropdowns): change color/spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@npmcorp/pui-css-colors": "^2.2.0",
     "@npmcorp/pui-css-dividers": "^2.0.0",
     "@npmcorp/pui-css-drop-down-menu": "^1.3.4",
-    "@npmcorp/pui-css-dropdowns": "^2.0.1",
+    "@npmcorp/pui-css-dropdowns": "^2.0.2",
     "@npmcorp/pui-css-ellipsis": "^2.0.0",
     "@npmcorp/pui-css-embeds": "^2.0.1",
     "@npmcorp/pui-css-forms": "^3.0.5",

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -27,15 +27,13 @@ This is the basic bootstrap dropdown.
     Button Dropdown
     <span class="caret"></span>
   </button>
-  <ul class="dropdown-menu" role="menu" aria-labelledby="dropdown-button-1">
+  <ul class="dropdown-menu dropdown-border" role="menu" aria-labelledby="dropdown-button-1">
     <li role="presentation">
       <a href="http://www.google.com" role="menuitem">Google</a>
     </li>
-    <li class="divider mvn"></li>
     <li role="presentation">
       <a href="http://www.yahoo.com" role="menuitem">Yahoo</a>
     </li>
-    <li class="divider mvn"></li>
     </li><li role="presentation">
       <a href="http://www.aol.com" role="menuitem">Aol</a>
     </li>
@@ -171,15 +169,16 @@ Here's a crazy-complex dropdown. Not for the faint of heart.
 }
 
 .dropdown-menu {
-  @include box-shadow(0 2px 0 rgba(211, 217, 217, 0.50));
+  @include box-shadow(0 1px 5px rgba(211, 217, 217, 0.60));
   background-color: white;
-  border: 1px solid $neutral-7;
+  border: 1px solid $dropdown-border;
   padding: 0 0;
 
   > li {
     > a {
       color: $dark-5;
       font-weight: 600;
+      padding: 10px 20px;
       &:hover {
         color: $dark-5;
         background-color: darken($neutral-11, 6%);
@@ -189,8 +188,6 @@ Here's a crazy-complex dropdown. Not for the faint of heart.
   &.dropdown-border {
     > li {
       > a {
-        padding-top: 7px;
-        padding-bottom: 7px;
         border-bottom: 1px solid $dropdown-border;
       }
     }

--- a/src/pivotal-ui/components/dropdowns/package.json
+++ b/src/pivotal-ui/components/dropdowns/package.json
@@ -4,5 +4,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "@npmcorp/pui-css-buttons": "^2.0.0"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -571,7 +571,7 @@ $cursor-disabled:                not-allowed !default;
 // -------------------------
 
 $dropdown-bg:                    $neutral-10 !default;
-$dropdown-border:                $neutral-9 !default;
+$dropdown-border:                $gray-5 !default;
 $dropdown-fallback-border:       transparent !default;
 $dropdown-divider-bg:            #e5e5e5 !default;
 


### PR DESCRIPTION
NOTE: needs #170 to be merged first

The border color, box shadow, and padding have all been changed to reflect
the new designs

This also changes the main example

OLD:
![olddropdown](https://cloud.githubusercontent.com/assets/109699/15477579/30c486d4-20ca-11e6-9d5b-b0cac6787e0a.png)

NEW:
![new-dropdown](https://cloud.githubusercontent.com/assets/109699/15477560/18b970d6-20ca-11e6-8d30-852e1d13b460.png)
