### PR TITLE
feat(dropdowns): use svg icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@npmcorp/pui-css-colors": "^2.2.0",
     "@npmcorp/pui-css-dividers": "^2.0.0",
     "@npmcorp/pui-css-drop-down-menu": "^1.3.4",
-    "@npmcorp/pui-css-dropdowns": "^2.1.0",
+    "@npmcorp/pui-css-dropdowns": "^2.3.0",
     "@npmcorp/pui-css-ellipsis": "^2.0.0",
     "@npmcorp/pui-css-embeds": "^2.0.1",
     "@npmcorp/pui-css-forms": "^3.0.5",

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -19,7 +19,6 @@ npm install @npmcorp/pui-css-dropdowns --save
 
 Dropdowns are menus that can be triggered by buttons.
 
-This is the basic bootstrap dropdown.
 
 NOTE: Each of these are using the icon for the svg, which you can access with the
 icon helper:
@@ -35,9 +34,57 @@ icon helper:
 
 ```
 
+This is the basic bootstrap dropdown.
+
 ```html_example
 <div class="dropdown">
   <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Button Dropdown
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
+
+  </button>
+  <ul class="dropdown-menu dropdown-border" role="menu" aria-labelledby="dropdown-button-1">
+    <li role="presentation">
+      <a href="http://www.google.com" role="menuitem">Google</a>
+    </li>
+    <li role="presentation">
+      <a href="http://www.yahoo.com" role="menuitem">Yahoo</a>
+    </li>
+    </li><li role="presentation">
+      <a href="http://www.aol.com" role="menuitem">Aol</a>
+    </li>
+  </ul>
+</div>
+```
+
+This is the basic bootstrap dropdown with a small button.
+
+```html_example
+<div class="dropdown">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-sm" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Button Dropdown
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
+
+  </button>
+  <ul class="dropdown-menu dropdown-border" role="menu" aria-labelledby="dropdown-button-1">
+    <li role="presentation">
+      <a href="http://www.google.com" role="menuitem">Google</a>
+    </li>
+    <li role="presentation">
+      <a href="http://www.yahoo.com" role="menuitem">Yahoo</a>
+    </li>
+    </li><li role="presentation">
+      <a href="http://www.aol.com" role="menuitem">Aol</a>
+    </li>
+  </ul>
+</div>
+```
+
+This is the basic bootstrap dropdown with a large button.
+
+```html_example
+<div class="dropdown">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-lg" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
 
@@ -230,9 +277,9 @@ Mix and match standard dropdown and tab styling as desired.
 
 ```html_example
 <div class="dropdown dropdown-driven-tabs">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default-alt" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
-    <span class="caret"></span>
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dropdown-button-1">
     <li role="presentation" class="active">
@@ -401,12 +448,9 @@ This is a notification dropdown with alerts.
   .caret {
     display: inline-block;
     border: 0;
-    margin-right: -0.6em;
-    padding-top: 7px;
-    margin-left: 5px;
-    margin-top: 0;
-    margin-bottom: 0;
-    font-size: 20px;
+    margin: 0 -0.5em 0 0.15em;
+    padding-top: 0.3em;
+    font-size: 1.25em;
   }
 }
 

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -38,7 +38,7 @@ This is the basic bootstrap dropdown.
 
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
 
@@ -61,7 +61,7 @@ This is the basic bootstrap dropdown with a small button.
 
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-sm" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-sm em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
 
@@ -84,7 +84,7 @@ This is the basic bootstrap dropdown with a large button.
 
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-lg" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default btn-lg em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
 
@@ -145,7 +145,7 @@ This is the basic bootstrap dropdown with a large button.
 
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
@@ -177,7 +177,7 @@ Here's a crazy-complex dropdown. Not for the faint of heart.
 
 ```html_example
 <div class="dropdown btn-group">
-  <button id="dropdown-button-2" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-2" class="dropdown-toggle btn btn-default em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     dropdown trigger
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
@@ -277,7 +277,7 @@ Mix and match standard dropdown and tab styling as desired.
 
 ```html_example
 <div class="dropdown dropdown-driven-tabs">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default em-low" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
     <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>

--- a/src/pivotal-ui/components/dropdowns/dropdowns.scss
+++ b/src/pivotal-ui/components/dropdowns/dropdowns.scss
@@ -21,11 +21,26 @@ Dropdowns are menus that can be triggered by buttons.
 
 This is the basic bootstrap dropdown.
 
+NOTE: Each of these are using the icon for the svg, which you can access with the
+icon helper:
+
+```html_example
+<svg style="display: none;">
+  <symbol id="i-arrow-down-selected" viewBox="0 0 56 28">
+    <path d="M56 1a1 1 0 0 0-1-1 .99.99 0 0 0-.69.282L54.306.28 28 25.61 1.693.28 1.69.282A.99.99 0 0 0 1 0a1 1 0 0 0-1 1c0 .283.12.536.31.718l-.003.003 27 26h.002a.99.99 0 0 0 1.38 0l.002.002 27-26-.002-.002A.994.994 0 0 0 56 1z"/>
+  </symbol>
+</svg>
+
+{{icon "@npm/glyphish/svg/g6/764-arrow-down-selected@2x" class="icon caret"}}
+
+```
+
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default-alt" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
-    <span class="caret"></span>
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
+
   </button>
   <ul class="dropdown-menu dropdown-border" role="menu" aria-labelledby="dropdown-button-1">
     <li role="presentation">
@@ -53,7 +68,8 @@ This is the basic bootstrap dropdown.
 <div class="dropdown">
   <button id="drop3" data-toggle="dropdown" class="dropdown-toggle btn btn-link" type="button">
     <span>Link Dropdown</span>
-    <span class="caret"></span>
+
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="drop3">
     <li role="presentation">
@@ -82,9 +98,9 @@ This is the basic bootstrap dropdown.
 
 ```html_example
 <div class="dropdown">
-  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default-alt" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-1" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     Button Dropdown
-    <span class="caret"></span>
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
   <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdown-button-1">
     <li role="presentation">
@@ -114,9 +130,9 @@ Here's a crazy-complex dropdown. Not for the faint of heart.
 
 ```html_example
 <div class="dropdown btn-group">
-  <button id="dropdown-button-2" class="dropdown-toggle btn btn-default-alt" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button id="dropdown-button-2" class="dropdown-toggle btn btn-default" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     dropdown trigger
-    <span class="caret"></span>
+    <svg class="icon caret"><use xlink:href="#i-arrow-down-selected"/></svg>
   </button>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dropdown-button-2">
     <li role="presentation">
@@ -381,6 +397,18 @@ This is a notification dropdown with alerts.
   }
 }
 
+.dropdown-toggle {
+  .caret {
+    display: inline-block;
+    border: 0;
+    margin-right: -0.6em;
+    padding-top: 7px;
+    margin-left: 5px;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 20px;
+  }
+}
 
 .dropdown-notifications {
   .caret {
@@ -433,6 +461,7 @@ This is a notification dropdown with alerts.
       left: 0.75em;
       right: auto;
     }
+
   }
 
   .dropdown-menu {

--- a/src/pivotal-ui/components/dropdowns/package.json
+++ b/src/pivotal-ui/components/dropdowns/package.json
@@ -5,5 +5,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "@npmcorp/pui-css-buttons": "^2.2.0"
   },
-  "version": "2.2.0"
+  "version": "2.3.0"
 }

--- a/src/pivotal-ui/components/dropdowns/package.json
+++ b/src/pivotal-ui/components/dropdowns/package.json
@@ -5,5 +5,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "@npmcorp/pui-css-buttons": "^2.2.0"
   },
-  "version": "2.3.0"
+  "version": "2.3.1"
 }


### PR DESCRIPTION
Update that includes using svg icon for dropdown caret +
make sure that the documentation is updated and better looking

![screen shot 2016-06-01 at 12 03 54 pm](https://cloud.githubusercontent.com/assets/109699/15722132/ef33ae38-27f0-11e6-8a40-92b51974dbaf.png)
