### PR TITLE
feat(buttons): add btn-tertiary class

### DIFF
--- a/src/pivotal-ui/components/buttons/buttons.scss
+++ b/src/pivotal-ui/components/buttons/buttons.scss
@@ -101,6 +101,12 @@ parent: button
         <td>This button should be used for the secondary action on the page. e.g. the upgrade button in the signup flow</td>
     </tr>
     <tr>
+        <td><button class="btn btn-tertiary">Tertiary</button></td>
+        <td><button class="btn btn-tertiary" disabled="">Tertiary</button></td>
+        <td style="white-space: nowrap"><code class="styleguide">btn btn-tertiary</code></td>
+        <td>This button should be used whenever necessary. e.g. the Platform dropdown on the Enterprise install page</td>
+    </tr>
+    <tr>
         <td><button class="btn btn-primary">Primary</button></td>
         <td><button class="btn btn-primary" disabled="">Primary</button></td>
         <td style="white-space: nowrap"><code class="styleguide">btn btn-primary</code></td>
@@ -165,6 +171,10 @@ parent: button
   &:hover {
     background: linear-gradient(0deg, saturate($btn-secondary-gradient-color, 60%) 0%, rgba(255, 255, 255, 0) 100%);
   }
+}
+
+.btn-tertiary {
+  @include button-skin($btn-tertiary-color, $btn-tertiary-bg, $btn-tertiary-border, null, $btn-tertiary-border-hover, $btn-tertiary-bg-hover);
 }
 
 .btn-link {

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -503,6 +503,12 @@ $btn-secondary-border:           $npm-brand;
 $btn-secondary-border-hover:     darken($npm-brand, 10%);
 $btn-secondary-gradient-color:   rgba(202, 56, 56, 0.15);
 
+$btn-tertiary-color:             $npm-brand;
+$btn-tertiary-bg:                $neutral-11;
+$btn-tertiary-bg-hover:          lighten($npm-brand, 47%);
+$btn-tertiary-border:            $npm-brand;
+$btn-tertiary-border-hover:      darken($npm-brand, 10%);
+
 $btn-link-color:                 $link-color !default;
 $btn-link-bg:                    transparent !default;
 


### PR DESCRIPTION
Based on designs for [this story](https://www.pivotaltracker.com/story/show/119305019) and [that story](https://www.pivotaltracker.com/story/show/116933333). It's basically a "flat" version of `btn-secondary`.

Here's what it looks like:
![btn-tertiary](https://cloud.githubusercontent.com/assets/1929625/15753933/d0f4c4ec-28c3-11e6-963d-01931003e142.gif)
