### PR TITLE
 fix(drop-down-menu): make sure build is ordered properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@npmcorp/pui-css-collapse": "^2.0.1",
     "@npmcorp/pui-css-colors": "^2.2.0",
     "@npmcorp/pui-css-dividers": "^2.0.0",
-    "@npmcorp/pui-css-drop-down-menu": "^1.3.4",
+    "@npmcorp/pui-css-drop-down-menu": "^1.3.5",
     "@npmcorp/pui-css-dropdowns": "^2.4.0",
     "@npmcorp/pui-css-ellipsis": "^2.0.0",
     "@npmcorp/pui-css-embeds": "^2.0.1",

--- a/src/pivotal-ui/components/drop-down-menu/package.json
+++ b/src/pivotal-ui/components/drop-down-menu/package.json
@@ -3,7 +3,10 @@
   "main": "drop-down-menu.js",
   "dependencies": {
       "jquery": "^2.1.4",
-      "@npmcorp/pui-css-typography": "^4.0.0"
+      "@npmcorp/pui-css-typography": "^4.0.0",
+      "@npmcorp/pui-css-links": "^3.0.0",
+      "@npmcorp/pui-css-buttons": "^2.3.0"
+
     },
-  "version": "1.3.4"
+  "version": "1.3.5"
 }


### PR DESCRIPTION
Depending on links and buttons makes sure that any overrides that
drop-down-menu provides will not be taken out by defaults
