### PR TITLE
feat(links): Add alternate link

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@npmcorp/pui-css-iconography": "^4.0.1",
     "@npmcorp/pui-css-images": "^2.0.1",
     "@npmcorp/pui-css-labels": "^2.0.1",
-    "@npmcorp/pui-css-links": "^3.0.0",
+    "@npmcorp/pui-css-links": "^3.1.0",
     "@npmcorp/pui-css-lists": "^2.4.2",
     "@npmcorp/pui-css-logoblock": "^1.0.0",
     "@npmcorp/pui-css-marketing": "^1.2.0",

--- a/src/pivotal-ui/components/links/links.scss
+++ b/src/pivotal-ui/components/links/links.scss
@@ -33,6 +33,7 @@ you should choose the default link.
 Link                                                                                                              | Class                           | Description
 --------------------------------------------------------------------------------------------------------------    | ----------------------------    | -----------
 <a class="link-text" href="http://bit.ly/1ulOAW7" target="_blank">default link</a>                                | `link-text`                     | Important links
+<a class="link-text link-alt" href="http://bit.ly/1ulOAW7" target="_blank">alternate link</a>                     | `link-text link-alt`            | Alternate link color
 <a class="link-text link-lowlight" href="http://bit.ly/1ulOAW7" target="_blank">lowlight link</a>                 | `link-text link-lowlight`       | Less important links
 <a class="link-text link-inverse bg-dark-1" href="http://bit.ly/1ulOAW7" target="_blank">inverse link</a>         | `link-text link-inverse`        | I go on a non-white background
 
@@ -70,6 +71,17 @@ a{
   }
 }
 
+.link-alt {
+  color: $link-alt-color;
+
+  &:hover, &:focus {
+    color: lighten($link-alt-color, 6%);
+  }
+
+  &:active, &.active {
+    color: darken($link-alt-color, 6%);
+  }
+}
 
 .link-lowlight {
   font-weight: $link-lowlight-font-weight;
@@ -83,6 +95,7 @@ a{
     color: darken($link-lowlight-color, 6%);
   }
 }
+
 
 .link-simple {
   @extends .link-lowlight;

--- a/src/pivotal-ui/components/links/package.json
+++ b/src/pivotal-ui/components/links/package.json
@@ -3,5 +3,5 @@
   "dependencies": {
     "@npmcorp/pui-css-bootstrap": "^2.0.0"
   },
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/src/pivotal-ui/components/pui-variables.scss
+++ b/src/pivotal-ui/components/pui-variables.scss
@@ -311,6 +311,7 @@ $link-hover-decoration:                   underline !default;
 $link-lowlight-color:                     $dark-5;
 $link-lowlight-font-weight:               600;
 
+$link-alt-color:                          $npm-blue-3;
 $link-inverse-color:                      $accent-5;
 
 


### PR DESCRIPTION
Making an npm-blue-3 link that is alternate, in case we want a link in the content that doesn't match the npm brand red.

[Finishes: #121090725]
