### PR TITLE
feat(forms): link updater input error animation

### DIFF
--- a/src/pivotal-ui/components/forms/forms.scss
+++ b/src/pivotal-ui/components/forms/forms.scss
@@ -1427,6 +1427,10 @@ The link updater input updates a link underneath the input with the information 
     <p class="mtl">https://www.npmjs.com/~<strong>username</strong></p>
   </div>
 </div>
+<div class="form-group">
+  <label for="example">Example for error handling</label>
+  <input name="example" id="example-for-error-handling" class="form-control">
+</div>
 ```
 
 For an organization name input:
@@ -1439,11 +1443,29 @@ For an organization name input:
     <p class="mtl">https://www.npmjs.com/org/<strong>your-org-name</strong></p>
   </div>
 </div>
+<div class="form-group">
+  <label for="example">Example for error handling</label>
+  <input name="example" id="example-for-error-handling-2" class="form-control">
+</div>
 ```
 */
 
 .link-updater-container {
+  transition: margin-bottom .1s;
+
+  .link-updater {
+    position: relative;
+  }
   p {
     color: $form-label-color;
+  }
+
+  &.has-error {
+    margin-bottom: 35px;
+  }
+
+  .has-error {
+    position: absolute;
+    bottom: -35px;
   }
 }

--- a/src/pivotal-ui/components/forms/package.json
+++ b/src/pivotal-ui/components/forms/package.json
@@ -5,5 +5,5 @@
     "@npmcorp/pui-css-bootstrap": "^2.0.0",
     "npm-user-validate": "^0.1.3"
   },
-  "version": "3.3.0"
+  "version": "3.4.0"
 }


### PR DESCRIPTION
Now, the link updater input animates open when an error happens, so the
experience of the error message isn't as jarring.

![error-animation](https://cloud.githubusercontent.com/assets/109699/16054408/d911570a-3221-11e6-8c15-bc63f00d8220.gif)
