### PR TITLE
fix(header): replace "on-site" with "enterprise" in search input placeholder

### DIFF
--- a/src/pivotal-ui/components/header/header.hbs
+++ b/src/pivotal-ui/components/header/header.hbs
@@ -16,7 +16,7 @@
       <meta itemprop="target" content="{{env.CANONICAL_HOST}}/search?q={q}">
       <div id="site-search-container">
         {{#if features.npmo}}
-          <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find on-site packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
+          <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find enterprise packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
         {{else}}
           <input name="q" value="{{q}}" type="search" id="site-search" placeholder="find packages" tabindex="1" autocorrect="off" autocapitalize="off" itemprop="query-input" />
         {{/if}}


### PR DESCRIPTION
Just because it shows up front-and-center in npmE and we no longer use the "on-site" brand/name.
