### PR TITLE
chore(gulp): make gulp release-update-package-versions more resilient

### DIFF
--- a/tasks/helpers/git-helper.js
+++ b/tasks/helpers/git-helper.js
@@ -7,7 +7,8 @@ const globPromise = promisify(require('glob'));
 let exec = promisify(require('child_process').exec);
 
 export function getTagFromTagString(tagString) {
-  return tagString.split('-').slice(0, -2).join('-');
+  // should handle values like `v5.1.1\n` or `v2.0.0-alpha.4-7-gc936d0b`
+  return tagString.trim().split('-').slice(0, 2).join('-');
 }
 
 export function isBlank(string) {
@@ -21,7 +22,8 @@ export function getPathsFromDiff(diff) {
 }
 
 export async function getLastTag() {
-  const tagString = await exec('git fetch && git describe --tags origin/master');
+  await exec('git fetch');
+  const tagString = await exec('git describe --tags origin/master');
   return getTagFromTagString(tagString);
 }
 

--- a/tasks/release-prepare.js
+++ b/tasks/release-prepare.js
@@ -49,13 +49,14 @@ gulp.task('release-update-version', (done) => {
     });
 });
 
-gulp.task('release-update-package-versions', (done) => {
-  componentsWithChanges().then((components) => {
+gulp.task('release-update-package-versions', () => {
+  // return promise instead of relying on callback
+  // to avoid silent errors and incomplete tasks
+  return componentsWithChanges().then((components) => {
     readArray(components)
       .pipe(componentsToUpdate())
       .pipe(updatePackageJsons())
-      .pipe(gulp.dest('.'))
-      .on('end', done);
+      .pipe(gulp.dest('.'));
   });
 });
 


### PR DESCRIPTION
By handling tag names like `v5.1.1\n` and by failing on error rather than silently giving up on the task.

I found this was necessary when playing with/working on the release process/gulp scripts. Apparently the `getLastTag()` and `getTagFromTagString(tagString)` functions are highly dependent on the current state of your local git repo (whether or not you have fetched recently) and what the name of the previous tag is (it was expecting values like `v2.0.0-alpha.4-7-gc936d0b` instead of `v5.1.1\n`). I fixed this to support both, returning the appropriate tag name instead of an empty string (which would result in an `undefined` array element returned from the `componentsWithChanges()` helper function). 

Also, if an error was encountered during the `release-update-package-versions` task (e.g. an unhandled rejection), the error would not be logged, the build would not fail, and the task would not complete (would timeout I suppose). This affected the parent `release-prepare` task too. This was fixed by returning the promise instead of attempting to handle the `done` callback manually.
