### PR TITLE
chore(gulp): maintain a single set of release artifacts under one directory

### DIFF
--- a/tasks/helpers/release-folder-helper.js
+++ b/tasks/helpers/release-folder-helper.js
@@ -2,15 +2,10 @@ import {map, pipeline} from 'event-stream';
 import gulp from 'gulp';
 import path from 'path';
 
-import {getNewVersion} from './version-helper';
-
 export function releaseDest(folderName='') {
   const prefixReleaseToDestStream = map(async (file, callback) => {
     try {
-      const version = getNewVersion();
-      if (file.path.indexOf(`pui-v${version}`) === -1) {
-        file.path = path.join(file.base, `pui-v${version}`, folderName, file.relative);
-      }
+      if (folderName) file.path = path.join(file.base, folderName, file.relative);
       callback(null, file);
     }
     catch(e) {

--- a/tasks/release-prepare.js
+++ b/tasks/release-prepare.js
@@ -9,6 +9,7 @@ import changelog from 'conventional-changelog';
 import {log} from 'gulp-util';
 import source from 'vinyl-source-stream';
 import semver from 'semver';
+import del from 'del';
 import {argv} from 'yargs';
 
 
@@ -81,6 +82,8 @@ gulp.task('release-generate-changelog', () => {
     .pipe(gulp.dest('.'));
 });
 
+gulp.task('release-clean-release-folder', callback => del(['release/*'], callback));
+
 gulp.task('release-generate-release-folder', ['monolith'], () => {
   const oocssStream = gulp.src([
     'src/oocss/utils/_clearfix-me.scss',
@@ -133,19 +136,15 @@ gulp.task('release-commit', () =>
   )
 );
 
-gulp.task('release-prepare', (done) => {
-  log(
-    argv.withDir
-    ? 'Will create release directory since --with-dir flag given'
-    : 'Will *NOT* create release directory since --with-dir flag not given'
-  )
+gulp.task('release-prepare', (done) =>
   runSequence(
     'release-update-version',
     [
       'release-update-package-versions',
-      'release-generate-changelog',
-      argv.withDir ? 'release-generate-release-folder' : 'monolith'
+      'release-generate-changelog'
     ],
+    'release-clean-release-folder',
+    'release-generate-release-folder',
     done
   )
-});
+);

--- a/tasks/release-prepare.js
+++ b/tasks/release-prepare.js
@@ -133,14 +133,19 @@ gulp.task('release-commit', () =>
   )
 );
 
-gulp.task('release-prepare', (done) =>
+gulp.task('release-prepare', (done) => {
+  log(
+    argv.withDir
+    ? 'Will create release directory since --with-dir flag given'
+    : 'Will *NOT* create release directory since --with-dir flag not given'
+  )
   runSequence(
     'release-update-version',
     [
       'release-update-package-versions',
       'release-generate-changelog',
-      'release-generate-release-folder'
+      argv.withDir ? 'release-generate-release-folder' : 'monolith'
     ],
     done
   )
-);
+});


### PR DESCRIPTION
Changes the behavior of `gulp release-prepare` such that a new version-specific directory is not created under `release/` ~~unless a new `--with-dir` flag is given on the command line~~ but rather release artifacts are overwritten in the `release/` dir for each new release.
#### Problem

The current release process creates a new version-specific directory for each release in the git repo, which means each release adds more "perpetual" static content and grows the size of the repo unnecessarily each time we create a release. Right now we don't use these release artifacts, so it seems wasteful to let them pile up in the repo, especially since each tag will contain the release artifacts for every previous release.
#### Possible Solutions
1. Do not add release artifacts to the git repo at all
   
   As reflected by commit 91234fe (when the `--with-dir` CLI flag is not given). This was just the simplest thing I could think of, but after talking with @aredridel, I realized it may not be the best solution.
2. Maintain a single `release/` directory in the git repo and have the release process (gulp tasks) overwrite its contents on each new release
   
   As reflected by commit a0761d9. To me, this option (along with the assumption of tagging releases) is probably best, since it would still make version-specific release artifacts accessible from GitHub via tag references like `https://raw.githubusercontent.com/npm/pivotal-ui/v5.1.2/release/pivotal-ui.min.css` but would not accumulate release artifacts for every prior release in the master branch.
#### Discussion

This PR currently represents what I think is close to the best solution, but I also want to facilitate discussion about the problem and, hopefully, agreement about an appropriate solution. Please add comments with your feedback.
