### PR TITLE
fix(forms): link updater always shows demoValue when empty

### DIFF
--- a/src/pivotal-ui/components/forms/link-updater.js
+++ b/src/pivotal-ui/components/forms/link-updater.js
@@ -15,10 +15,10 @@ var LinkUpdater = function(el){
 };
 
 LinkUpdater.prototype.updateValue = function(inputValue){
-  if(!this.input[0].checkValidity() || isInvalid(inputValue)){
-    if(inputValue === "") {
-      this.pathDisplay.text(this.demoValue);
-    }
+  if(inputValue === "") {
+    this.pathDisplay.text(this.demoValue);
+  } else if (!this.input[0].checkValidity() || isInvalid(inputValue)){
+    //noop
   } else {
     this.pathDisplay.text(inputValue);
   }


### PR DESCRIPTION
Link updater was depending on constraint validation to handle empty
input values, but that's mixing concerns.
