### PR TITLE
fix(forms): Validator now works w/ input-error evt

### DIFF
--- a/src/pivotal-ui/components/forms/link-updater.js
+++ b/src/pivotal-ui/components/forms/link-updater.js
@@ -1,8 +1,6 @@
 var $ = require('jquery');
 var isInvalid = require('npm-user-validate').username;
 
-var errorClass = "has-error";
-
 var LinkUpdater = function(el){
   this.el = $(el);
   this.updater = this.el.find(".link-updater");
@@ -22,11 +20,14 @@ LinkUpdater.prototype.updateValue = function(inputValue){
   if(err) {
     inputValue = this.currentValue;
     this.input.val(this.currentValue);
-    this.showError(err.message);
-  } else if(!this.input[0].checkValidity()) {
-    this.showError(this.input[0].validationMessage);
-  } else {
-    this.hideError();
+    // setImmediate forces input-error to be triggered on the next tick, so it
+    // will follow any input
+    setImmediate(function(){
+      this.input.trigger({
+        type: "input-error",
+        message: err.message
+      });
+    }.bind(this));
   }
 
   var pathVal = inputValue;
@@ -39,24 +40,6 @@ LinkUpdater.prototype.updateValue = function(inputValue){
   this.pathDisplay.text(pathVal);
 };
 
-LinkUpdater.prototype.showError = function(msg){
-  var err = this.updater.find("." + errorClass);
-
-  if(!err.length) {
-    err = $("<span class='help-block " + errorClass + "'>" + msg + "</span>");
-
-    this.el.addClass(errorClass);
-    this.updater.append(err);
-  } else {
-    err.text(msg);
-  }
-
-};
-
-LinkUpdater.prototype.hideError = function(){
-  this.el.removeClass(errorClass);
-  this.updater.find("." + errorClass).remove();
-};
 
 $(function(){
   var linkUpdater = $(".link-updater-container");


### PR DESCRIPTION
There was a collision within the link-updater where we were deferring
the ability to handle all errors to it. This meant that if any other
types of validation were to occur on a link-updater type input, then
further duplication of error handling would have to be performed.

This commit removes that and instead creates an interface for the
validator that consumes input errors and adds/removes errors
accordingly. This gives back the error handling control to the
validator, where it belongs.

This fixes an issue that was found where the no match validation module
was colliding with link-updater.

[Finishes #126324861]
