### PR TITLE
fix(svgeople): Remove explicit dependency on forms

### DIFF
--- a/src/pivotal-ui/components/svgeople/index.js
+++ b/src/pivotal-ui/components/svgeople/index.js
@@ -1,5 +1,4 @@
 var $ = require('jquery');
-require('@npmcorp/pui-css-forms').stepper;
 
 /**
  * SVGeople constructor takes 4 arguments

--- a/src/pivotal-ui/components/svgeople/package.json
+++ b/src/pivotal-ui/components/svgeople/package.json
@@ -1,8 +1,7 @@
 {
   "homepage": "http://styleguide.pivotal.io/objects.html#svgeople",
   "dependencies": {
-    "@npmcorp/pui-css-bootstrap": "6.2.1",
-    "@npmcorp/pui-css-forms": "6.3.0"
+    "@npmcorp/pui-css-bootstrap": "6.2.1"
   },
   "version": "6.3.0"
 }


### PR DESCRIPTION
This isn't needed as the stepper is neither referenced nor directly coupled.
