### PR TITLE
feat(tables): Rounded corner tables

### DIFF
--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -120,35 +120,35 @@ user lists with permissions and action menus
 
 */
 
-.table-friendly {
+table.table-friendly { // tag name included to get enough specificity to override bootstrap rules.
   border-collapse: separate;
-  >thead:first-child>tr:first-child, >tfoot:first-child>tr:first-child, >tbody:first-child>tr:first-child, >tr:first-child {
-    >th:first-child, >td:first-child {
+  > :first-child > tr:first-child, > tr:first-child {
+    > :first-child {
       border-top-left-radius: 10px !important;
     }
-    >th:last-child, >td:last-child {
+    > :last-child {
       border-top-right-radius: 10px !important;
     }
-    >th, >td {
+    >td, >th {
       border-top: 1px solid $gray-8;
     }
   }
-  >thead>tr, >tbody>tr, >tfoot>tr, >tr {
-    >:first-child {
+  > * > tr, > tr {
+    > :first-child {
       border-left: 1px solid $gray-8;
     }
-    >:last-child {
+    > :last-child {
       border-right: 1px solid $gray-8;
     }
   }
-  >thead:last-child>tr:last-child, >tfoot:last-child>tr:last-child, >tbody:last-child>tr:last-child, >tr:last-child {
-    >th:first-child, >td:first-child {
+  > :last-child > tr:last-child, > tr:last-child {
+    > :first-child {
       border-bottom-left-radius: 10px !important;
     }
-    >th:last-child, >td:last-child {
+    > :last-child {
       border-bottom-right-radius: 10px !important;
     }
-    >th, >td {
+    > td, > th {
       border-bottom: 1px solid $gray-8;
     }
   }
@@ -180,8 +180,8 @@ Table header colors:
 */
 
 .table-header-gray-10 {
-  >thead>tr, >tfoot>tr, >tr {
-    >th, >td {
+  > * > tr, > tr {
+    > th, > td {
       background-color: $gray-10;
     }
   }

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -73,6 +73,123 @@ table, .table {
 
 /*doc
 ---
+title: Rounded Table
+name: 1_table_round
+parent: table
+---
+
+This is a table used to display many rows of data, with headers and
+footers. Use it for tables of information or associations such as
+user lists with permissions and action menus
+
+```html_example
+<table class="table table-rounded table-header-gray-10">
+  <thead>
+    <tr>
+      <th>Wombat Type</th>
+      <th>Surprisingness</th>
+      <th>Cuteness</th>
+    </tr>
+  </thead>
+  <tbody class="bg-neutral-11">
+    <tr>
+      <td>Baby Wombat</td>
+      <td>100</td>
+      <td>Infinity</td>
+    </tr>
+    <tr>
+      <td>World's Largest</td>
+      <td>1000</td>
+      <td>99.5</td>
+    </tr>
+    <tr>
+      <td>In native habitat</td>
+      <td>12</td>
+      <td>315</td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <th>Average</th>
+      <td>506</td>
+      <td>Infinity</td>
+    </tr>
+  </tfoot>
+</table>
+```
+
+*/
+
+.table-rounded {
+  border-collapse: separate;
+  >thead:first-child>tr:first-child, >tfoot:first-child>tr:first-child, >tbody:first-child>tr:first-child, >tr:first-child {
+    >th:first-child, >td:first-child {
+      border-top-left-radius: 10px !important;
+    }
+    >th:last-child, >td:last-child {
+      border-top-right-radius: 10px !important;
+    }
+    >th, >td {
+      border-top: 1px solid $gray-8;
+    }
+  }
+  >thead>tr, >tbody>tr, >tfoot>tr, >tr {
+    >:first-child {
+      border-left: 1px solid $gray-8;
+    }
+    >:last-child {
+      border-right: 1px solid $gray-8;
+    }
+  }
+  >thead:last-child>tr:last-child, >tfoot:last-child>tr:last-child, >tbody:last-child>tr:last-child, >tr:last-child {
+    >th:first-child, >td:first-child {
+      border-bottom-left-radius: 10px !important;
+    }
+    >th:last-child, >td:last-child {
+      border-bottom-right-radius: 10px !important;
+    }
+    >th, >td {
+      border-bottom: 1px solid $gray-8;
+    }
+  }
+}
+
+/*doc
+---
+title: Header Color
+name: table_header_color
+parent: table
+---
+
+Table header colors:
+
+```html_example
+<table class="table table-rounded table-header-gray-10">
+  <thead>
+    <tr><th>Greeting</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Hello, World</td></tr>
+  </tbody>
+  <tfoot>
+    <tr><th>Winning!</th></tr>
+  </tfoot>
+</table>
+```
+
+*/
+
+.table-header-gray-10 {
+  >thead>tr, >tfoot>tr, >tr {
+    >th, >td {
+      background-color: $gray-10;
+    }
+  }
+}
+
+
+/*doc
+---
 title: Data
 name: 1_table_data
 parent: table

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -73,8 +73,8 @@ table, .table {
 
 /*doc
 ---
-title: Rounded Table
-name: 1_table_round
+title: Friendly Table
+name: 1_table_friendly
 parent: table
 ---
 
@@ -83,7 +83,7 @@ footers. Use it for tables of information or associations such as
 user lists with permissions and action menus
 
 ```html_example
-<table class="table table-rounded table-header-gray-10">
+<table class="table table-friendly table-header-gray-10">
   <thead>
     <tr>
       <th>Wombat Type</th>
@@ -120,7 +120,7 @@ user lists with permissions and action menus
 
 */
 
-.table-rounded {
+.table-friendly {
   border-collapse: separate;
   >thead:first-child>tr:first-child, >tfoot:first-child>tr:first-child, >tbody:first-child>tr:first-child, >tr:first-child {
     >th:first-child, >td:first-child {
@@ -164,7 +164,7 @@ parent: table
 Table header colors:
 
 ```html_example
-<table class="table table-rounded table-header-gray-10">
+<table class="table table-friendly table-header-gray-10">
   <thead>
     <tr><th>Greeting</th></tr>
   </thead>

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -152,38 +152,8 @@ table.table-friendly { // tag name included to get enough specificity to overrid
       border-bottom: 1px solid $gray-8;
     }
   }
-}
-
-/*doc
----
-title: Header Color
-name: table_header_color
-parent: table
----
-
-Table header colors:
-
-```html_example
-<table class="table table-friendly table-header-gray-10">
-  <thead>
-    <tr><th>Greeting</th></tr>
-  </thead>
-  <tbody>
-    <tr><td>Hello, World</td></tr>
-  </tbody>
-  <tfoot>
-    <tr><th>Winning!</th></tr>
-  </tfoot>
-</table>
-```
-
-*/
-
-.table-header-gray-10 {
-  > * > tr, > tr {
-    > th, > td {
-      background-color: $gray-10;
-    }
+  > thead, > tfoot {
+    background-color: $gray-10;
   }
 }
 

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -234,7 +234,7 @@ This is a table used to display many rows of data.
 
 /*doc
 ---
-title: Alternate
+title: Alternate (Deprecated)
 name: 2_table_alt
 parent: table
 ---

--- a/src/pivotal-ui/components/tables/tables.scss
+++ b/src/pivotal-ui/components/tables/tables.scss
@@ -190,12 +190,12 @@ Table header colors:
 
 /*doc
 ---
-title: Data
+title: Data (Deprecated)
 name: 1_table_data
 parent: table
 ---
 
-This is a table used to display many rows of data (it is pretty much the default table).
+This is a table used to display many rows of data.
 
 ```html_example
 <div class="panel panel-basic-alt panel-table-wrapper">


### PR DESCRIPTION
Because rounding corners with a wrapping panel and `overflow: hidden` causes drop-down menus to not be able to cover a table, we have to implement rounded tables without clipping.

This moves the background onto the _cells_ of `th` and `td` within `thead` and `tfoot`, and creates a class for the header color style, orthogonal to the rounding.

The borders are applied to the corner cells themselves, since tables and thead/tbody/tfoot don't contain their children in the traditional layout sense.
