### PR TITLE
feat(forms): data-validate-event

### DIFF
--- a/src/pivotal-ui/components/forms/forms.scss
+++ b/src/pivotal-ui/components/forms/forms.scss
@@ -1656,7 +1656,7 @@ insert this code:
 var isGiraffeInput = $(input).attr("name") === "gotta-say-giraffe";
 
 if(isGiraffeInput) {
-  if(input.value !== 'giraffe'){
+  if($(input).val() !== 'giraffe'){
     input.setCustomValidity("This must say giraffe");
   } else {
     input.setCustomValidity("");
@@ -1680,11 +1680,18 @@ if(isLinkUpdater) {
 }
 ```
 
-Setting the custom validity to a value will mean you're informing the browser that
+Setting the custom validity to a value will mean you are informing the browser that
 there is indeed an error here. If you set the value to an empty string, that means
 that there no longer is an error.
 
 To use this validation on your form, add <code>data-validate</code> to the form element.
+
+By default, our inputs only validate on <code>blur</code>. This means that we only will check
+correctness if the user leaves the input element or removes focus from the element. If you would
+like to have the validator validate on the <code>input</code> event (on any user input) as well
+as when focus is taken away, add the data attribute and value <code>data-validate-event="input blur"</code>.
+
+If you would only like to listen to the <code>input></code> event, try <code>data-validate-event="input"</code>.
 
 
 ```html_example
@@ -1718,7 +1725,7 @@ To use this validation on your form, add <code>data-validate</code> to the form 
   <div class="form-group link-updater-container">
     <label for="name">Username</label>
     <div class="link-updater input-wrapper">
-      <input class="form-control" id="name" name="name" placeholder="username" required="" type="text">
+      <input class="form-control" id="name" name="name" placeholder="username" required="" type="text" data-validate-event="input blur">
       <p class="mtl">https://www.npmjs.com/~<strong>username</strong></p>
     </div>
   </div>
@@ -1752,6 +1759,7 @@ To use this validation on your form, add <code>data-validate</code> to the form 
   </p>
 </form>
 ```
+
 */
 
 $form-input-error-height: 35px;

--- a/src/pivotal-ui/components/forms/validator.js
+++ b/src/pivotal-ui/components/forms/validator.js
@@ -1,5 +1,11 @@
 var $ = require('jquery');
 
+var isEventListenedFor = function isEventListenedFor(input, event, standard) {
+  var events = $(input).data("validate-event") || "";
+
+  return (standard && events.length === 0) || (events.length > 0 && events.split(" ").indexOf(event) > -1);
+};
+
 var addError = function addError(input, err) {
   var msg = err || input.validationMessage;
   $(input).closest(".form-group").addClass('has-error');
@@ -23,6 +29,10 @@ var handleSubmit = function handleSubmit(e){
 };
 
 var handleBlur = function handleBlur(e) {
+  if(!isEventListenedFor(e.target, "blur", true)){
+    return;
+  }
+
   this.reflectValidity(e.target);
 };
 
@@ -30,6 +40,11 @@ var handleInput = function handleInput(e) {
   var input = e.target;
   var $input = $(input);
   var err;
+
+
+  if(!isEventListenedFor(input, "input")) {
+    return;
+  }
 
   var isNoMatch = $input.is("[data-validate-nomatch]");
 
@@ -52,6 +67,11 @@ var handleInput = function handleInput(e) {
 var handleInputError = function handleInputError(e) {
   var input = e.target;
   var message = e.message;
+
+  if(!isEventListenedFor(input, "input")) {
+    return;
+  }
+
 
   this.reflectValidity(input, message);
 };


### PR DESCRIPTION
Currently, our forms validate on both `blur` and `input` events by
default. This change will make sure only the `blur` event is on by
default.

From a usability standpoint, this means that we will only check for
correctness when a user takes focus away from an input, instead of
whenever a user adds any input or when the focus is removed.

If you'd like the `input` event to also be listened for, you must add
the `data-validate-event` data attribute with `blur input` as the value.
This will allow us to track like we did before.

If you'd like only the `input` event to be listened for, you can omit
`blur` and only write `data-validate-event="input"`.

[Finishes #128322423]

BREAKING CHANGE: Any input that we would also like to listen for `input`
will need this attribute added. This includes all `link-updater` and
`nomatch` inputs.
