### PR TITLE
fix(forms): Remove absolute positioning on errors

### DIFF
--- a/src/pivotal-ui/components/forms/forms.scss
+++ b/src/pivotal-ui/components/forms/forms.scss
@@ -1585,23 +1585,15 @@ For an organization name input:
 */
 
 .link-updater-container {
-  transition: margin-bottom .1s;
-
-  .link-updater {
-    position: relative;
-  }
   p {
     color: $form-label-color;
     word-break: break-all;
   }
 
   &.has-error {
-    margin-bottom: 35px;
-  }
-
-  .has-error {
-    position: absolute;
-    bottom: -35px;
+    p {
+      margin-bottom: 3px;
+    }
   }
 }
 
@@ -1691,7 +1683,7 @@ correctness if the user leaves the input element or removes focus from the eleme
 like to have the validator validate on the <code>input</code> event (on any user input) as well
 as when focus is taken away, add the data attribute and value <code>data-validate-event="input blur"</code>.
 
-If you would only like to listen to the <code>input></code> event, try <code>data-validate-event="input"</code>.
+If you would only like to listen to the <code>input</code> event, try <code>data-validate-event="input"</code>.
 
 
 ```html_example
@@ -1762,21 +1754,13 @@ If you would only like to listen to the <code>input></code> event, try <code>dat
 
 */
 
-$form-input-error-height: 35px;
-
 .form-group {
-  transition: margin-bottom .1s;
-
-  .input-wrapper {
-    position: relative;
-  }
 
   &.has-error {
-    margin-bottom: $form-input-error-height;
+    margin-bottom: 0;
   }
 
   .has-error {
-    position: absolute;
-    bottom: -$form-input-error-height;
+    margin-top: 7px;
   }
 }

--- a/src/pivotal-ui/components/forms/validator.js
+++ b/src/pivotal-ui/components/forms/validator.js
@@ -9,12 +9,12 @@ var isEventListenedFor = function isEventListenedFor(input, event, standard) {
 var addError = function addError(input, err) {
   var msg = err || input.validationMessage;
   $(input).closest(".form-group").addClass('has-error');
-  $(input).closest(".input-wrapper").append("<span class='help-block has-error'>" + msg + "</span>");
+  $(input).closest(".input-wrapper").append($("<span class='help-block has-error'>" + msg + "</span>").hide().slideDown(100));
 };
 
 var removeError = function removeError(input) {
   $(input).closest(".form-group").removeClass('has-error');
-  $(input).closest(".input-wrapper").find(".has-error").remove();
+  $(input).closest(".input-wrapper").find(".has-error").slideUp(100).promise().then(function(el){ $(el).remove() });
 };
 
 


### PR DESCRIPTION
Absolute positioning was a fun hack that allowed for a really nice
display, but made this thing unworkable with other stacked errors.

We've moved ourselves to a js-based transition and block-positioned
elements in order to get away from that.

This will require screenshots of both the existing and the new version
in order to compare/contrast make sure they look exactly the same so
this won't break current views
