### PR TITLE
fix(header): place in higher context for clicking

### DIFF
--- a/src/pivotal-ui/components/header/header.scss
+++ b/src/pivotal-ui/components/header/header.scss
@@ -52,7 +52,7 @@ View the [regular header on its own page](/header.html) to see mobile sizing fea
 */
 
 header {
-  z-index: 0; // A separate rendering context because browsers are 💩 and full of bugs.
+  z-index: 2; // A separate rendering context because browsers are 💩 and full of bugs.
   font-size: 16px;
   padding: 0.875em 20px 0.0625em;
   border-bottom: 1px solid #d3d3d3;


### PR DESCRIPTION
The drop down menu was being covered as the header was being placed
underneath the context of invisible pieces on screen-fill-body pages